### PR TITLE
Improvement: Nest all endpoints under another layer in menu

### DIFF
--- a/source/includes/_endpoints.md
+++ b/source/includes/_endpoints.md
@@ -1,0 +1,1 @@
+# Endpoints

--- a/source/includes/endpoints/_activities.md
+++ b/source/includes/endpoints/_activities.md
@@ -1,4 +1,4 @@
-# Activities
+## Activities
 Activities hold communications to and from your Accelo deployment, such as client communication, meetings, and notes. See the [support documentation](https://www.accelo.com/resources/help/guides/user/activities-and-tasks/activities-notes-and-emails/) for more information on activities.
 
 > Resource URI:  
@@ -14,7 +14,7 @@ The Activity object is complex and contains some special objects:
 * [Activity Interactions](#activity-interactions)
 * [Time Allocations](#the-time-allocation-object)
 
-## The Activity Object
+### The Activity Object
 > Sample activity object:
 
 ```json
@@ -88,7 +88,7 @@ The activities object contains the following fields:
 | invoice_id | unsigned | The unique identifier of the [invoice](#invoices) the activity is attached to, if any. |
 | contract_period_id | unsigned | The unique identifier of the [contract period](#the-contract-period) the activity is attached to, if any. |
 
-### Activity Medium
+#### Activity Medium
 Activities are communicative objects, e.g. notes and emails. The type of communication is described by the "medium", Accelo currently supports five types of media for activities:  
 
 | Name | Description |
@@ -100,7 +100,7 @@ Activities are communicative objects, e.g. notes and emails. The type of communi
 | Postal | Log information about letters or packages you have sent to contacts, such as package tracking numbers. |
 
 
-### Activity Visibility
+#### Activity Visibility
 Activities also have a visibility associated with them, which determines how they are viewed by others. The visibility of an activity can be set to one of three values:
 
 | Visibility | Description |
@@ -109,7 +109,7 @@ Activities also have a visibility associated with them, which determines how the
 | Confidential | Hides full content of this activity and replaces with the word "Confidential". Other users see that a Confidential Activity has occurred on the date but will see no other details. |
 | All | Displays full content of this activity to all users. |
 
-### The Activity Class
+#### The Activity Class
 Classes are an additional field for further describing Activities, you may add or remove classes from your deployment through the configuration menu, this process is outlined in the Accelo [support documentation](https://www.accelo.com/resources/help/guides/user/activities-and-tasks/activities-notes-and-emails/set-up-and-customize/classes/). By default your Accelo deployment will have three classes:
 
 
@@ -141,7 +141,7 @@ The class object for activities will contain the following:
 
 **Note:** This object does not support the `_ALL` argument with [`_fields`](#configuring-the-response-fields)
 
-### The Activity Priority
+#### The Activity Priority
 > Sample JSON of an activity priority:
 
 ```json
@@ -161,7 +161,7 @@ The activity priority describes the urgency of a given activity, it contains the
 
 **Note:** This object does not support the `_ALL` argument with [`_fields`](#configuring-the-response-fields)
 
-### Activity Threads and Parents
+#### Activity Threads and Parents
 
 > Activity threads and parents:  
 
@@ -175,7 +175,7 @@ Naturally, we expect these communicative objects to build off each other, for ex
 
 We will describe these with an example. Imagine an email is sent out as `activities/56`, then this email is responded to by two new emails `activities/57` and `activity/59`, imagine further that the email `activities/59` is responded to by another email, `activities/62`. In this case, each activity will have a `thread` of `activities/56`, `activities/57` and `activities/59` will have a `parent` of `activities/56`, and `activities/62` will have a parent of `activities/59`.
 
-#### The Activity Thread Object
+##### The Activity Thread Object
 > Sample JSON of an activity thread object:
 
 ```json
@@ -200,13 +200,13 @@ Activity threads are described by the thread object, this contains the following
 | **total_activities** | integer | A count of the number of activities in the thread. |
 
 
-### Activity Interactions
+#### Activity Interactions
 In the context of activities, an interaction is a recipient or sender of an activity, this will either be a staff, or affiliation or contact object. An activity can have several interactions; an email may be sent to several staff members and an affiliation. The form of interactions, and the way they are handled vary depending on the context, thus we deal with each case individually:  
 
 1. [Interactions with a list of activities](#get-activities-handling-interacts)   
 2. [List of interactions with a single activity](#get-activities-id-interacts)
 
-### The Time Allocation Object
+#### The Time Allocation Object
 When an activity includes logging time the time logged is described by the time allocation object, this contains the following:
 
 | Field | Type | Description |
@@ -227,7 +227,7 @@ When an activity includes logging time the time logged is described by the time 
 
 
 
-## Get Activity
+### Get Activity
 `GET /activities/{activity_id}`
 
 > Sample request:  
@@ -250,10 +250,10 @@ curl -X get \
 ```
 If successful, this request returns an activity identified by its `activity_id`.
 
-### Configuring the Response
+#### Configuring the Response
 this request supports requesting additional fields and linked objects from the [activity object](#the-activity-object) using the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-### Handling the Response
+#### Handling the Response
 The response will be the [activity](#the-activity-object) with its default fields and any additional fields requested through `_fields`.
 
 > Sample response, excluding meta:
@@ -275,7 +275,7 @@ The response will be the [activity](#the-activity-object) with its default field
 
 
 
-## List Activities
+### List Activities
 `GET /activities`
 
 > Sample request:  
@@ -303,16 +303,16 @@ curl -X get \
 
 This request will return a list of activities on the Accelo deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
 
-#### Pagination
+##### Pagination
 This request supports all the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects from the [activity object](#the-activity-object) using the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-#### Basic Filters
+##### Basic Filters
 This request supports [basic filters](#filters-basic-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -334,7 +334,7 @@ This request supports [basic filters](#filters-basic-filters) over the following
 
 
 
-#### Date Filters
+##### Date Filters
 > Sample response:
 
 ```json
@@ -382,7 +382,7 @@ This request supports [date filters](#filters-date-filters) over the following f
 | date_modified |
 
 
-#### Order Filters
+##### Order Filters
 This request supports [order filters](#filters-order-filters) over the following fields:
 
 | Filter Name |
@@ -395,7 +395,7 @@ This request supports [order filters](#filters-order-filters) over the following
 | billable |
 | nonbillable |
 
-#### Range Filters
+##### Range Filters
 This request supports [range filters](#filters-range-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -409,7 +409,7 @@ This request supports [range filters](#filters-range-filters) over the following
 | class | Range over the `class_id`. |
 | task | Range over the `task_id`. |
 
-#### Object Filters
+##### Object Filters
 This request supports [object filters](#filters-object-filters) over the following linked object:
 
 | Filter Name | Description |
@@ -417,10 +417,10 @@ This request supports [object filters](#filters-object-filters) over the followi
 | owner | Filter by activities owned by these objects. |
 | against | Filter by activities against these objects. |
 
-### Handling the Response
+#### Handling the Response
 The response will be a List of [activities](#the-activity-object) with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters or filters used.
 
-### Handling Interacts
+#### Handling Interacts
 > Sample response, here we are looking at the interactions of a single activity.
 
 ```json
@@ -491,7 +491,7 @@ That is, each activity has an interaction where each interaction identifies an o
 
 
 
-## Count Activities
+### Count Activities
 > Sample request, here we request the response as xml
 
 ```http
@@ -528,7 +528,7 @@ This request will return a count of activities in a list defined by any availabl
 
 
 
-## List Interactions
+### List Interactions
 
 ```http
 GET /api/v0/activities/{activity_id}/interacts HTTP/1.1
@@ -580,10 +580,10 @@ This request returns an array of activity interactions for the activity identifi
 }
 ```
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [staff](#the-activity-object) and [contact](#the-contact-object) objects using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will contain two arrays:
 
 | Name | Description |
@@ -608,7 +608,7 @@ The staff and contact objects returned will contain their default fields, plus a
 
 
 
-## Count Interactions
+### Count Interactions
 > Sample request:
 
 ```http
@@ -646,7 +646,7 @@ This request will return a count of activity threads in a list defined by any av
 
 
 
-## Get Time Allocated
+### Get Time Allocated
 > Sample Request:  
 
 `GET /activities/allocations`
@@ -678,10 +678,10 @@ This request returns information on timed logged and the value charged against a
 ```
 
 
-### Configuring the Response
+#### Configuring the Response
 This request supports the same filters as [`GET /activities`](#list-activities), these filters are used to define the collection of activities from which the request takes the allocation data.
 
-### handling the Response
+#### handling the Response
 The response will contain the following fields describing the allocations for the activities:
 
 | Field | Type | Description |
@@ -696,7 +696,7 @@ The response will contain the following fields describing the allocations for th
 
 
 
-## Update an Activity
+### Update an Activity
 `PUT /activities/{activity_id}`
 
 > Sample request, we wish to update and return the priority field:
@@ -721,7 +721,7 @@ curl -X put \
 ```
 This request will update, and return, the identified activity.
 
-### Configuring the Activity
+#### Configuring the Activity
 The following fields from the [activity object](#the-activity-object) may be updated through this request:
 
 | Field | Conditions |
@@ -751,10 +751,10 @@ The following fields from the [activity object](#the-activity-object) may be upd
 }
 ```
 
-### Configuring the response
+#### Configuring the response
 This request supports requesting additional fields and linked objects from the [activity object](#the-activity-object) using the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-### Handling the Response
+#### Handling the Response
 The response will be the single, updated [activity](#the-activity-object) with its default fields and any additional fields requested through `_fields`.
 
 
@@ -763,7 +763,7 @@ The response will be the single, updated [activity](#the-activity-object) with i
 
 
 
-## Create an Activity
+### Create an Activity
 `POST /activities`
 
 > Sample request, here we send the data as json:
@@ -797,7 +797,7 @@ curl -X post \
 
 This request will create, and return, a new [activity](#the-activity-object) on the deployment.
 
-### Configuring the Activity
+#### Configuring the Activity
 Values for the following fields may be set through this request.
 
 | Field | Notes |
@@ -826,7 +826,7 @@ Values for the following fields may be set through this request.
 | billable | As above, but also requires the activity is against an [issue](#issues), [job](#jobs-projects), [milestone](#milestones), [contract](#contracts), or [period](#contract-periods)|
 
 
-### Including "to", "cc" and "bcc" Interactions
+#### Including "to", "cc" and "bcc" Interactions
 > Sample json request segment to add interactions. In this case we would create an activity to staff with id 10, cc'ing affiliations 13 and 14 and bcc'ing the email recipient "bcc-recipient@affinitylive.com".
 
 ```json
@@ -854,18 +854,18 @@ We can create interactions with our activity by sending our request as JSON (see
 
 Each object accepts a staff or affiliation (identified by their id) or a general email.
 
-### Logging time
+#### Logging time
 
 The billable and nonbillable attributes require that you supply a staff owner (owner_type and owner_id) otherwise no time allocation is created against the new activity. i.e, the user who the time belongs to.
 
-### Logging time against a task
+#### Logging time against a task
 
 To log an activity against a task, you should pass in the task's against_id and against_type as the new activity's against_id and against_type. Essentially you are creating an activity against the object the task is against.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [activity object](#the-activity-object) using the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-### Handling the Response
+#### Handling the Response
 The response will be the new [activity](#the-activity-object) with its default fields and any additional fields requested through `_fields`
 
 
@@ -875,7 +875,7 @@ The response will be the new [activity](#the-activity-object) with its default f
 
 
 
-## Delete Activity
+### Delete Activity
 > Sample Request:  
 
 ```http
@@ -900,7 +900,7 @@ This request will delete the activity identified by its `activity_id`. This requ
 
 
 
-## List Activity Threads
+### List Activity Threads
 > Sample Request:  
 
 ```http
@@ -922,15 +922,15 @@ curl -X get \
 
 This request returns a list of [activity threads](#the-activity-thread-object).
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all of the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects from the [activity object](#the-activity-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-#### Basic Filters
+##### Basic Filters
 This request supports [basic filters](#filters-basic-filters) over the following fields:
 
 > Sample response of a single thread:  
@@ -956,7 +956,7 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | staff_involved | Filter by the `staff_id` the staff member(s) who have interacted with activities within the thread. |
 | scope | Takes either "internal" or "external" as arguments, whether the thread is external, such as emails from clients, or internal, such as notes. |
 
-#### Date Filters
+##### Date Filters
 This request supports [date filters](#filters-date-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -964,7 +964,7 @@ This request supports [date filters](#filters-date-filters) over the following f
 | date_logged_after | Filter by threads that have activities with `date_logged` after this time. |
 | date_logged_before | Filter by threads that have activities with `date_logged` before this time. |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [activity threads](#the-activity-thread-object), displayed according to any pagination parameters or searches used. The activity listed under the `activities` array of the thread will be displayed with its default fields and any additional fields requested through `_fields`.
 
 
@@ -973,7 +973,7 @@ The response will be a list of [activity threads](#the-activity-thread-object), 
 
 
 
-## Count Activity Threads
+### Count Activity Threads
 > Sample Request:  
 
 ```http
@@ -1002,7 +1002,7 @@ This request will return a count of activity threads in a list defined by any av
 
 
 
-## List Activities in a Thread
+### List Activities in a Thread
 > Sample request:  
 
 ```http

--- a/source/includes/endpoints/_addresses.md
+++ b/source/includes/endpoints/_addresses.md
@@ -1,10 +1,10 @@
-# Addresses
+## Addresses
 > Resource URI:    
 `/api/v0/adddresses`
 
 The Addresses endpoint stores the address information of companies and contacts on the Accelo deployment.
 
-## The Address Object
+### The Address Object
 > Sample address object:
 
 ```json
@@ -41,7 +41,7 @@ The address object contains the following:
 | physical | string | This will be either "yes" or "no", if this address is a physical address of not. |
 
 
-### The Country Object
+#### The Country Object
 > JSON country object for the USA:
 
 ```json
@@ -85,7 +85,7 @@ This object contains the details of a country. It is made up of the following fi
 | state_required | boolean | Whether a state needs to be specified for addresses in this country. |
 | postcode_required | boolean | Whether a postcode needs to be specified for addresses in this country. |
 
-### The State Object
+#### The State Object
 > JSON object for NSW, Australia:
 
 ```json
@@ -123,10 +123,10 @@ This object contains the details of a state within a given country. It is made u
 | ordering | unsigned | The state's order as displayed on the Accelo deployment. |
 | timezone | string | The name of the timezeone the state obeys. For example "Australia/Sydney", "Europe/London". |
 
-### Postal and Physical Addresses
+#### Postal and Physical Addresses
 An address in Accelo may be physical or postal or both. For example, a company may have an office that is both a physical and postal address, but also have a post office box that is only a postal address.
 
-### The Address Object
+#### The Address Object
 
 > Example JSON of full address object:
 
@@ -154,7 +154,7 @@ An address in Accelo may be physical or postal or both. For example, a company m
 
 
 
-## Get Address
+### Get Address
 > Sample Request:    
 
 ```http
@@ -197,10 +197,10 @@ curl -X get \
 
 This request will return the address identified by its `address_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [address object](#the-address-object) through the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be a single address object containing the default fields and any other fields included via the `_fields` parameter.
 
 
@@ -211,7 +211,7 @@ The response will be a single address object containing the default fields and a
 
 
 
-## List Addresses
+### List Addresses
 > Sample request:
 
 ```http
@@ -232,12 +232,12 @@ curl -X get \
 This request returns a list of addresses on the Accelo deployment.
 
 <a name="get-addresses-configuring-the-response"></a>
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Basic Filters
+##### Basic Filters
 This request supports [basic filters](#filters-basic-filters) over the following  fields:
 
 | Filter Name | Notes |
@@ -251,7 +251,7 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | state_id ||
 | zipcode | Filter over the postcode field. |
 
-#### Range Filters
+##### Range Filters
 This request supports [range filters](#filters-range-filters) over the following fields:
 
 | Filter Name |
@@ -259,7 +259,7 @@ This request supports [range filters](#filters-range-filters) over the following
 | id |
 | against_id |
 
-#### Order Filters
+##### Order Filters
 This request supports [order filters](#filters-order-filters) over the following fields:
 
 | Filter Name |
@@ -269,7 +269,7 @@ This request supports [order filters](#filters-order-filters) over the following
 | suffix |
 | prefix |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [addresses](#the-address-object) with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters or filters used.
 
 
@@ -279,7 +279,7 @@ The response will be a list of [addresses](#the-address-object) with their defau
 
 
 
-## Count Addresses
+### Count Addresses
 > Sample request:
 
 ```http
@@ -307,7 +307,7 @@ This request will return a count of addresses in a list defined by any available
 
 
 
-## List Addresses Against an Object
+### List Addresses Against an Object
 > Sample request:
 
 
@@ -335,10 +335,10 @@ This request returns all addresses against the object of type `{object}` and uni
 
 For example, the request `GET /companies/39/addresses` would return all addresses registered with the company with id 39.
 
-### Configuring the Response
+#### Configuring the Response
 This request may be configured as [`GET /addresses`](#list-addresses)
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of addresses against the identified object with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters or filters used.
 
 
@@ -347,7 +347,7 @@ The response will be a list of addresses against the identified object with thei
 
 
 
-## Update an Address
+### Update an Address
 `PUT /addresses/{address_id}`
 
 ```http
@@ -379,7 +379,7 @@ curl -X put
 
 This request updates and returns an [address](#the-address-object) on the Accelo deployment specified by its unique `{address_id}`.
 
-### Configuring the Address
+#### Configuring the Address
 The following fields may be updated through this request:
 
 | Field | Notes |
@@ -396,10 +396,10 @@ The following fields may be updated through this request:
 | postal ||
 | physical ||
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [address object](#the-address-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be the single updated address object with its default fields and any fields added through the `_fields` parameter.
 
 
@@ -409,7 +409,7 @@ The response will be the single updated address object with its default fields a
 
 
 <a name="post-addresses"></a>
-## Create an Address
+### Create an Address
 > Sample request:
 
 ```http
@@ -430,7 +430,7 @@ curl -X post
 
 This request will create a new address and return it.
 
-### Configuring the Address
+#### Configuring the Address
 The address may be configured in the same manner as [`PUT /addresses/{address_id}`](#update-an-address), with the addition of the following fields:
 
 | Field | Type | Description |
@@ -439,10 +439,10 @@ The address may be configured in the same manner as [`PUT /addresses/{address_id
 | **against_id** | unsigned | The unique identifier of the object the address is against. |
 | overwrite | boolean | Whether to overwrite the address if the address to be created already exists. |
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [address object](#the-address-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be the single updated address object with its default fields and any fields added through the `_fields` parameter.
 
 
@@ -452,7 +452,7 @@ The response will be the single updated address object with its default fields a
 
 
 
-## Create an Address Against an Object
+### Create an Address Against an Object
 > Sample request:
 
 ```http

--- a/source/includes/endpoints/_affiliations.md
+++ b/source/includes/endpoints/_affiliations.md
@@ -1,4 +1,4 @@
-# Affiliations
+## Affiliations
 > Resources URI:  
 `/api/v0/affiliations`
 
@@ -8,7 +8,7 @@ They are necessary because one contact may be linked to a company in more than o
 
 For example we may have a contact who works as an engineer for one company (imaginatively, call it company A), and an advisor for another company (company B). Then there will be two affiliation objects, both with the same contact object, however, one will have the company object of Company A, and the other of Company B. Furthermore, the contact information (mobile, email etc.) for each affiliation may be different, one will hold the contact information for an engineer working at Company A, the other for an advisor working at Company B.
 
-## The Affiliation Object
+### The Affiliation Object
 > Sample affiliation JSON object:
 
 ```json
@@ -57,7 +57,7 @@ The Affiliation object contains the following:
 
 
 
-## Get Affiliation
+### Get Affiliation
 > Sample request:
 
 ```shell
@@ -78,10 +78,10 @@ Content-Type: application/x-www-form-urlencoded
 
 This request returns an affiliation specified by their unique id.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [affiliation object](#the-affiliation-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 If successful, the response will be a single affiliation object containing the default fields and any additional fields requested by `_fields`.
 
 
@@ -89,7 +89,7 @@ If successful, the response will be a single affiliation object containing the d
 
 
 
-## List Affiliations
+### List Affiliations
 > Sample request:
 
 ```http
@@ -116,12 +116,12 @@ curl -X get \
 
 This request returns a list of [affiliation objects](#the-affiliation-object) on the deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all of the [pagination](#configuring-the-response-pagination) parameters
 
-#### Basic Filters
+##### Basic Filters
 This request supports [basic filters](#filters-basic-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -136,14 +136,14 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | contact | Filter by the `contact_id` of the affiliations. |
 | contact_number | Filter over `phone`, `fax`, and `mobile`. |
 
-#### Date Filters
+##### Date Filters
 This request supports [date filters](#filters-date-filters) over the following fields:
 
 | Filter Name |
 |:-|
 | date_modified |
 
-#### Order Filters
+##### Order Filters
 This request supports [order filters](#filters-order-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -155,7 +155,7 @@ This request supports [order filters](#filters-order-filters) over the following
 | date_last_interacted ||
 | fullname | Order by the full name of the affiliation, that is "`firstname` `surname`". |
 
-#### Range Filters
+##### Range Filters
 This request supports range filters over the following fields:
 
 | Filter Name | Notes |
@@ -185,7 +185,7 @@ This request supports range filters over the following fields:
 ]
 ```
 
-#### Searching
+##### Searching
 This request supports the use of the [`_search`](#configuring-the-response-searching) parameter to search over the following fields:
 
 | Field Name | Notes |
@@ -197,7 +197,7 @@ This request supports the use of the [`_search`](#configuring-the-response-searc
 | mobile |
 | email |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [affiliations](#the-affiliation-object) with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters, filters or searches used.
 
 
@@ -205,7 +205,7 @@ The response will be a list of [affiliations](#the-affiliation-object) with thei
 
 
 
-## Count Affiliations
+### Count Affiliations
 > Sample request:
 
 ```shell
@@ -233,7 +233,7 @@ This request will return a count of affiliations in a list defined by any availa
 
 
 
-## Get Affiliation Status
+### Get Affiliation Status
 > Sample request:
 
 
@@ -264,10 +264,10 @@ This request returns the [status object](#statuses) for the affiliation specifie
 }
 ```
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [status object](#statuses) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be a [status object](#statuses) for the specified [affiliation](#the-affiliation-object) with its default fields and any additional fields requested through `_fields`.
 
 
@@ -275,7 +275,7 @@ The response will be a [status object](#statuses) for the specified [affiliation
 
 
 
-## Update an Affiliation
+### Update an Affiliation
 ```http
 PUT /api/v0/affiliations/{affiliation_id} HTTP/1.1
 Host: {deployment}.api.accelo.com
@@ -302,7 +302,7 @@ curl -X put \
 This request will update and return an [affiliation](#the-affiliation-object) identified by its `affiliation_id`.
 
 
-### Configuring the Affiliation.
+#### Configuring the Affiliation.
 
 The following fields may be updated via this request.
 
@@ -335,10 +335,10 @@ The following fields may be updated via this request.
 }
 ```
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [affiliation object](#the-affiliation-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be the single updated [affiliation object](#the-affiliation-object), with its default fields and any additional fields requested through `_fields`
 
 
@@ -346,7 +346,7 @@ The response will be the single updated [affiliation object](#the-affiliation-ob
 
 
 
-## Create an Affiliation
+### Create an Affiliation
 ```http
 POST /api/v0/affiliations/ HTTP/1.1
 Host: {deployment}.api.accelo.com
@@ -365,7 +365,7 @@ curl -X post \
 
 This request will create a new [affiliation](#the-affiliation-object) between a [company](#companies) and [contact](#contacts) (to be specified in the request), and return it.
 
-### Configuring the Affiliation
+#### Configuring the Affiliation
 This request supports setting the following fields:
 
 | Field Name | Notes |
@@ -385,10 +385,10 @@ This request supports setting the following fields:
 | communication | Must be "yes" or "no", whether or not communications, such as updates, newsletters etc. are sent to this affiliation, default "no".|
 | invoice_method | e.g. "email", "fax" or "postal", the method by which invoices should be sent. |
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [affiliation object](#the-affiliation-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be the single, new, [affiliation object](#the-affiliation-object), with its default fields and any additional fields requested through `_fields`
 
 
@@ -396,7 +396,7 @@ The response will be the single, new, [affiliation object](#the-affiliation-obje
 
 
 
-## Delete an Affiliation
+### Delete an Affiliation
 ```http
 DELETE /api/v0/affiliations/{affiliation_id} HTTP/1.1
 Host: {deployment}.api.accelo.com
@@ -418,7 +418,7 @@ This request will delete the affiliation identified by its `affiliation_id`. Thi
 
 
 
-## List Profile Field Values
+### List Profile Field Values
 > See the [profiles section](#retrieve-a-list-of-profile-values) for a sample request
 
 `GET /affiliations/{affiliation_id}/profiles/values`
@@ -430,7 +430,7 @@ This request returns a list of [profile field values](#the-profile-value-object)
 
 
 
-## List Profile Fields
+### List Profile Fields
 > See the [profiles section](#retrieve-a-list-of-profile-fields) for a sample request  
 
 `GET /affiliations/profiles/fields`
@@ -443,7 +443,7 @@ This request returns a list of [profile fields](#the-profile-field-object) avail
 
 
 
-## Update a Profile Field Value
+### Update a Profile Field Value
 > See the [profiles section](#update-a-profile-value-link) for a sample request  
 
 `PUT /affiliations/{affiliation_id}/profiles/values/{profile_value_id}`
@@ -458,7 +458,7 @@ This request updates and returns a [profile field value](#the-profile-value-obje
 
 
 
-## Set a Profile Field Value
+### Set a Profile Field Value
 > See the [profiles section](#create-a-profile-value-link) for a sample request
 
 `POST /affiliations/{affiliation_id}/profiles/fields/{profile_field_id}`
@@ -473,7 +473,7 @@ This request sets and returns a [profile value](#the-profile-value-object) for a
 
 
 
-## List Available Progressions
+### List Available Progressions
 > See the [progressions section](#retrieve-a-list-of-available-progressions) for a sample request
 
 `GET /affiliations/{affiliation_id}/progressions`
@@ -486,7 +486,7 @@ This request returns a list of available [progressions](#progressions) for an [a
 
 
 
-## Auto Run a Progression
+### Auto Run a Progression
 > See the [progressions section](#run-a-status-update-using-a-given-progression) for a sample request
 
 `[PUT | POST] /affiliations/{affiliation_id}/progressions/{progression_id}/auto`

--- a/source/includes/endpoints/_assets.md
+++ b/source/includes/endpoints/_assets.md
@@ -1,10 +1,10 @@
-# Assets
+## Assets
 > Endpoint URI:  
 `/api/v0/assets`
 
 Assets are flexible objects within Accelo, they can represent almost any asset or object you want. For example, you may wish to store information on the computers owned by your company, or the prices of advertising media offered by external companies. For more information see the [support documentation](https://www.accelo.com/resources/help/guides/user/modules/assets/).
 
-## The Asset Object
+### The Asset Object
 The asset object contains the following:
 
 > Sample JSON asset:
@@ -46,7 +46,7 @@ The asset object contains the following:
 | address | unsigned or object | The physical [address](#addresses) associated with this asset (if any). |
 | address_id | unsigned | The unique identifier of the physical address assigned to the asset.  |
 
-### The Asset Link (Beta)
+#### The Asset Link (Beta)
 > Sample JSON asset link:
 
 ```json
@@ -84,7 +84,7 @@ An asset may be linked to an [issue](#issues), [job](#jobs-projects), [prospect]
 If any of the fields labelled optional above are empty, they will not be displayed.
 
 
-### The Asset Type (Beta)
+#### The Asset Type (Beta)
 
 > Sample JSON asset type:
 
@@ -112,7 +112,7 @@ If any of the fields labelled optional above are empty, they will not be display
 | has_address | binary | Whether the asset type has an address assigned to it. |
 | ordering  | unsigned | An integer representing the asset type's ordering on the deployment. |
 
-### Asset Object Link Fields (Beta)
+#### Asset Object Link Fields (Beta)
 > Sample json object link fields object:
 
 ```json
@@ -152,7 +152,7 @@ These contain information on the properties of assets of a given type linked to 
 
 
 
-## Get Asset
+### Get Asset
 ```http
 GET /assets/{asset_id} HTTP/1.1
 Host: {deployment}.api.accelo.com
@@ -169,10 +169,10 @@ curl -X get \
 
 This request will return a single asset, specified by its unique identifier.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [asset object](#the-asset-object) using the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-### Handling the Response
+#### Handling the Response
 The response will contain the single asset object with its default fields and any others included via the `_fields` parameter
 
 
@@ -180,7 +180,7 @@ The response will contain the single asset object with its default fields and an
 
 
 
-## List Assets
+### List Assets
 > Sample Request:  
 
 ```http
@@ -199,15 +199,15 @@ curl -X get \
 
 This request will return a list of assets on the Accelo deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all of the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects from the [asset object](#the-asset-object) using the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-#### Basic Filters
+##### Basic Filters
 This request supports [basic filters](#filters-basic-filters) over the following fields:
 
 | Filter Name |
@@ -221,14 +221,14 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | against_type |
 | against_id |
 
-#### Date Filters
+##### Date Filters
 This request supports [date filters](#filters-date-filters) over the following fields:
 
 | Filter Name |
 |:-|
 | date_created |
 
-#### Order Filters
+##### Order Filters
 This request supports [order filters](#filters-order-filters) over the following fields:
 
 | Filter Name |
@@ -237,7 +237,7 @@ This request supports [order filters](#filters-order-filters) over the following
 | date_created |
 | standing |
 
-#### Range Filters
+##### Range Filters
 This request supports [range filters](#filters-range-filters) over the following fields:
 
 | Filter Name |
@@ -249,21 +249,21 @@ This request supports [range filters](#filters-range-filters) over the following
 | manager_id |
 | address_id |
 
-#### Object Filters
+##### Object Filters
 This request supports the following [object filters](#filters-object-filters):
 
 | Filter Name | Notes |
 |:-|:-|
 | against | Filter by assets against these objects. |
 
-#### Searching
+##### Searching
 This supports the [`_search`](#configuring-the-response-searching) parameter to search over the following fields:
 
 | Filter Name |
 |:-|
 | title |
 
-### handling the Response
+#### handling the Response
 The response will be a list of [asset objects](#the-asset-object) with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters, filters or searches used.
 
 
@@ -271,7 +271,7 @@ The response will be a list of [asset objects](#the-asset-object) with their def
 
 
 
-## Count Assets
+### Count Assets
 > Sample Request:  
 
 ```http
@@ -299,7 +299,7 @@ This request will return a count of assets in a list defined by any available se
 
 
 
-## Get Asset Type (Beta)
+### Get Asset Type (Beta)
 > Sample request:
 
 ```http
@@ -318,17 +318,17 @@ curl -X get \
 
 This request returns a single [asset type](#the-asset-type-beta) specified by its `type_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [asset type object](#the-asset-type-beta) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be the single asset type with its default fields and any additional fields requested through `_fields`.
 
 
 
 
 
-## List Asset Types (Beta)
+### List Asset Types (Beta)
 > Sample request:
 
 ```http
@@ -347,15 +347,15 @@ curl -X get \
 
 This request returns a list of [asset types](#the-asset-type-beta).
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination 
+##### Pagination 
 This request supports all the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects from the [asset type](#the-asset-type-beta) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-#### Basic Filters
+##### Basic Filters
 This request supports [basic filters](#filters-basic-filters) over the following fields:
 
 | Field Name |
@@ -363,7 +363,7 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | id |
 | standing |
 
-#### Order Filters
+##### Order Filters
 This request supports [order filters](#filters-order-filters) over the following fields:
 
 | Filter Name |
@@ -372,28 +372,28 @@ This request supports [order filters](#filters-order-filters) over the following
 | standing |
 | title |
 
-#### Range Filters
+##### Range Filters
 This request supports [range filters](#filters-range-filters) over the following fields:
 
 | Filter Name |
 |:-|
 | id |
 
-#### Searching
+##### Searching
 This request supports the use of the [`_search`](#configuring-the-response-searching) parameter to search over the following fields:
 
 | Field Name |
 |:-|
 | title |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of asset types with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters, filters or searches used.
 
 
 
 
 
-## List Asset Links (Beta)
+### List Asset Links (Beta)
 
 > Sample request:
 
@@ -411,16 +411,16 @@ curl -X get \
 
 This request returns an array of [asset links](#the-asset-link-beta) and an array of the linked [assets](#the-asset-object).
 
-### Configuring the Response
+#### Configuring the Response
 Any additional parameters requested will be applied to the returned asset links.
 
-#### Pagination 
+##### Pagination 
 This request supports all the [pagination parameters](#configuring-the-response-pagination).
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 All fields of the asset link object are displayed by default. 
 
-#### Basic Filters
+##### Basic Filters
 This request supports the following [basic filters](#filters-basic-filters):
 
 | Filter |
@@ -428,14 +428,14 @@ This request supports the following [basic filters](#filters-basic-filters):
 | asset_link_id |
 | asset_id |
 
-#### Object Filters
+##### Object Filters
 This request supports [object filters](#filters-object-filters) over the following objects:
 
 | Object |
 |:-|
 | linked_object |
 
-#### Date Filters
+##### Date Filters
 This request supports the following [date filters](#filters-date-filters):
 
 | Filter |
@@ -443,7 +443,7 @@ This request supports the following [date filters](#filters-date-filters):
 | date_start |
 | date_end |
 
-#### Order Filters
+##### Order Filters
 This request supports the following [order filters](#filters-order-filters):
 
 | Filter |
@@ -452,21 +452,21 @@ This request supports the following [order filters](#filters-order-filters):
 | date_start |
 | date_end |
 
-#### Range Filters
+##### Range Filters
 This request supports the following [range filters](#filters-range-filters):
 
 | Filter |
 |:-|
 | asset_link_id |
 
-### Handling the Response
+#### Handling the Response
 The response will contain an array, "assets", of [asset](#the-asset-object) with their default fields with the removal of the `latest_asset_link` field, and the addition of the `breadcrumbs` field. The response will also contain an array, "asset_links" of [asset links](#the-asset-link-beta) with all their fields, and displayed according to any pagination parameters or filters used. 
 
 
 
 
 
-## Create Asset Link (Beta)
+### Create Asset Link (Beta)
 > Sample Request:
 
 ```http
@@ -487,7 +487,7 @@ curl -X POST \
 
 This request creates and returns an [asset link](#the-asset-link-beta) between an [asset](#the-asset-object) and an object from one of the supported types.
 
-### Configuring the Link
+#### Configuring the Link
 The following parameters may be sent to set the fields in the asset link:
 
 | Parameter | Type | Notes |
@@ -500,7 +500,7 @@ The following parameters may be sent to set the fields in the asset link:
 | start_date | unix ts | |
 
 
-### Handling the Response
+#### Handling the Response
 The response will be the newly created [asset link](#the-asset-link-beta).
 
 
@@ -508,7 +508,7 @@ The response will be the newly created [asset link](#the-asset-link-beta).
 
 
 
-## Delete Asset Link (Beta)
+### Delete Asset Link (Beta)
 
 > Sample Request:
 
@@ -533,7 +533,7 @@ This request deletes an asset link (and not the asset) specified by its `asset_l
 
 
 
-## List Extension Fields
+### List Extension Fields
 > See the [extension section](#retrieve-a-list-of-extension-fields) for an example    
 
 `GET /assets/extensions/fields`
@@ -546,7 +546,7 @@ This request returns a list of [extension fields](#the-extension-field-object) a
 
 
 
-## List Extension Field Values
+### List Extension Field Values
 > See the [extension section](#retrieve-a-list-of-extension-field-values) for an example     
 
 `GET /assets/{asset_id}/extensions/values`
@@ -559,7 +559,7 @@ This request returns a list of [extension values](#the-extension-value-object) f
 
 
 
-## Update an Extension Field Value
+### Update an Extension Field Value
 > See the [extension section](#update-an-extension-value) for an example     
 
 `PUT /assets/{asset_id}/extensions/values/{extension_value_id}`
@@ -572,7 +572,7 @@ This request updates the value of an [extension field value](#the-extension-valu
 
 
 
-## Set an Extension Field Value
+### Set an Extension Field Value
 > See the [extension section](#create-an-extension-value) for an example
 
 `POST /assets/{asset_id}/extensions/fields/{extension_field_id}`

--- a/source/includes/endpoints/_companies.md
+++ b/source/includes/endpoints/_companies.md
@@ -1,10 +1,10 @@
-# Companies
+## Companies
 > Resource URI:
 `/api/v0/companies`
 
 Companies are the entries in Accelo to note the companies with whom you interact. These can range from partners and vendors to your actual customers, and can even include you! These Client entries also act as the central repository for all information related to that group, including correspondence, project and sales updates, and contact information for their employees. See the [support documentation](https://www.accelo.com/resources/help/guides/user/modules/companies-and-contacts/) for more information on accessing and using companies on your deployment.
 
-## The Company Object
+### The Company Object
 > Example company object:
 
 ```json
@@ -45,7 +45,7 @@ Companies are the entries in Accelo to note the companies with whom you interact
 | staff_bookmarked | bool | Whether the company has been bookmarked by the current user. |
 | default_affiliation | unsigned | The `affiliation_id`  of the main [affiliation](#affiliations) associated with this company. |
 
-### The Manager Object
+#### The Manager Object
 > Example manager object with default fields:
 
 ```json
@@ -63,7 +63,7 @@ A company may be managed by a [staff member](#staff), this management relationsh
 |:-|:-|:-|
 | relationship_id | unsigned | A unique identifier for the relationship between the company and manager.
 
-### The Segmentation Object
+#### The Segmentation Object
 > Example segmentation:
 
 ```json
@@ -100,7 +100,7 @@ Segmentations may be managed through your Accelo deployment, see the [support do
 
 
 
-## Get Company
+### Get Company
 > Sample Request:  
 
 ```http
@@ -119,10 +119,10 @@ curl -X get \
 
 This request returns a single company from the Accelo deployment, identified by its `company_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [company object](#the-company-object)
 
-### Handling the Response
+#### Handling the Response
 The response will contain a company object with its default fields and any additional fields requested via the `_fields` parameter.
 
 
@@ -131,7 +131,7 @@ The response will contain a company object with its default fields and any addit
 
 
 
-## List Companies
+### List Companies
 > Sample Request:  
 
 ```http
@@ -150,15 +150,15 @@ curl -X get \
 
 This request returns a list of [companies](#the-company-object) from the Accelo deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all of the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects from the [company object](#the-company-object) using the `_fields` parameter.
 
-#### Basic Filters
+##### Basic Filters
 This request supports [basic filters](#filters-basic-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -173,7 +173,7 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | custom_id | Filter over the `custom_id`. |
 
 
-#### Date Filters
+##### Date Filters
 This request [date filters](#filters-date-filters) over the following fields:
 
 | Filter Name |
@@ -182,7 +182,7 @@ This request [date filters](#filters-date-filters) over the following fields:
 | date_modified |
 
 
-#### Order Filters
+##### Order Filters
 This request supports [order filters](#filters-order-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -196,7 +196,7 @@ This request supports [order filters](#filters-order-filters) over the following
 | status | Order by the `status_id`. |
 | custom_id ||
 
-#### Range Filters
+##### Range Filters
 This request supports [range filters](#filters-range-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -209,7 +209,7 @@ This request supports [range filters](#filters-range-filters) over the following
 | status | Range over the `status_id`.|
 | custom_id ||
 
-#### Searching
+##### Searching
 This request supports the [`_searching`](#configuring-the-response-searching) parameter to search over the following fields:
 
 | Field Name | Notes |
@@ -219,7 +219,7 @@ This request supports the [`_searching`](#configuring-the-response-searching) pa
 | phone ||
 | fax ||
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [company objects](#the-company-object) with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters, filters, or searches used.
 
 
@@ -228,7 +228,7 @@ The response will be a list of [company objects](#the-company-object) with their
 
 
 
-## Count Companies
+### Count Companies
 > Sample Request:    
 
 ```http
@@ -257,7 +257,7 @@ This request will return a count of companies in a list defined by any available
 
 
 
-## List Recent Companies
+### List Recent Companies
 > Sample Request:  
 
 ```http
@@ -286,10 +286,10 @@ Authorization: Bearer {access_token}
 
 This request returns the most recently created companies on the Accelo deployment. This request is equivalent to requesting all companies and ordering in descending order of `date_created`.
 
-### Configuring the Response
+#### Configuring the Response
 This request accepts the same parameters and filters as [`GET /companies`](#list-companies), although it will always be ordered in descending order of `date_created`
 
-### handling the Response
+#### handling the Response
 This request will return a list of [company objects](#the-company-object) with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters, filters, or searches used.
 
 
@@ -298,7 +298,7 @@ This request will return a list of [company objects](#the-company-object) with t
 
 
 
-## List Latest Modified Companies
+### List Latest Modified Companies
 > Sample Request:  
 
 ```http
@@ -327,10 +327,10 @@ Authorization: Bearer {access_token}
 
 This request returns the most recently changed companies on the Accelo deployment. This request is equivalent to requesting all companies and ordering in descending order of `date_modified`.
 
-### Configuring the Response
+#### Configuring the Response
 This request accepts the same parameters and filters as [`GET /companies`](#list-companies), although it will always be ordered in descending order of `date_modified`
 
-### Handling the Response
+#### Handling the Response
 This request will return a list of [company objects](#the-company-object) with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters, filters, or searches used.
 
 
@@ -339,7 +339,7 @@ This request will return a list of [company objects](#the-company-object) with t
 
 
 
-## Get Company Status
+### Get Company Status
 > Sample Request:  
 
 
@@ -359,10 +359,10 @@ curl -X get \
 
 This request returns the [status](#statuses) of a [company](#the-company-object) identified by its `company_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [status object](#statuses) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling The Response
+#### Handling The Response
 The response will be a single status object with its default fields and any additional fields requested via `_fields`.
 
 
@@ -371,7 +371,7 @@ The response will be a single status object with its default fields and any addi
 
 
 
-## Get Main Contact
+### Get Main Contact
 > Sample Request:  
 
 ```http
@@ -390,10 +390,10 @@ curl -X get \
 
 This request returns the main [contact](#contacts) of a company identified by its `{company_id}`. This is the contact associated with the company's `default_affiliation`.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [contact object](#contacts) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be a single [contact](#contact) with its default fields and any other additional fields requested via `_fields`.
 
 
@@ -402,7 +402,7 @@ The response will be a single [contact](#contact) with its default fields and an
 
 
 
-## List Contacts
+### List Contacts
 > Sample Request:  
 
 ```http
@@ -422,7 +422,7 @@ curl -X get \
 
 This request returns a list of [contacts](#contacts) for a company identified by its `{company_id}`.
 
-### Configuring the Response
+#### Configuring the Response
 This request may be configured and handled as per [`GET /contacts`](#list-contacts)
 
 
@@ -431,7 +431,7 @@ This request may be configured and handled as per [`GET /contacts`](#list-contac
 
 
 
-## Count Contacts
+### Count Contacts
 > Sample Request:  
 
 ```http
@@ -461,7 +461,7 @@ This request returns a count of a list of contacts associated with a company spe
 
 
 
-## List Managers
+### List Managers
 > Sample Request:  
 
 ```http
@@ -481,7 +481,7 @@ curl -X get \
 
 This request returns a list of [managers](#the-manager-object) of a company specified by its `company_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This request may be configured and handled a per [`GET /staff`](#list-staff)
 
 
@@ -490,7 +490,7 @@ This request may be configured and handled a per [`GET /staff`](#list-staff)
 
 
 
-## List Segmentations
+### List Segmentations
 > Sample Request:   
 
 ```http
@@ -552,7 +552,7 @@ This request returns a list of [segmentations](#the-segmentation-object) for a c
 
 
 
-## Update a Company
+### Update a Company
 > Example request:
 
 ```http
@@ -578,7 +578,7 @@ curl -X put \
 
 This request updates and returns a [company](#the-company-object) identified by its `company_id`.
 
-### Configuring the Company
+#### Configuring the Company
 The following fields from the [company object](#the-company-object) may be updated through this request:
 
 | Field |
@@ -588,10 +588,10 @@ The following fields from the [company object](#the-company-object) may be updat
 | fax |
 | comments |
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [company object](#the-company-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Response
+#### Response
 This request returns the single updated company object, with its default fields and any additional fields requesting through `_fields`.
 
 
@@ -600,7 +600,7 @@ This request returns the single updated company object, with its default fields 
 
 
 
-## Create a Company
+### Create a Company
 
 > Sample request:  
 
@@ -631,7 +631,7 @@ curl -X post \
 
 This request creates a new company on the Accelo deployment, and returns it.
 
-### Configuring the Company
+#### Configuring the Company
 Values for the following fields from the [company object](#the-company-object) may be sent with this request:
 
 | Field | Notes |
@@ -645,13 +645,13 @@ Values for the following fields from the [company object](#the-company-object) m
 | fax | |
 | comments | |
 
-#### Setting Profile Field Values
+##### Setting Profile Field Values
 [Profile field values](#profiles) may be set when you create a company, for a given profile value identified by `profile_value_id` you may update it through the field "profile.{`profile_value_id`}".
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [company object](#the-company-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### handling the Response
+#### handling the Response
 This request returns the created company object, with its default fields and any additional fields requesting through `_fields`.
 
 
@@ -660,7 +660,7 @@ This request returns the created company object, with its default fields and any
 
 
 
-## Add a Manager
+### Add a Manager
 > Sample Request:  
 
 ```http
@@ -684,7 +684,7 @@ curl -X post \
 
 This request adds a [manager](#the-manager-object), identified by their unique `staff_id`, as a manager to a company, identified by its unique `company_id`. The request returns a list of managers of this company on the Accelo deployment.
 
-### Configuring the Manager
+#### Configuring the Manager
 The following fields may be sent with this request:
 
 | Field | Type | Description |
@@ -692,7 +692,7 @@ The following fields may be sent with this request:
 | **manager_id** | unsigned | The `staff_id` of the staff member to be set as the manager of the company. |
 | nature | select | Nature of the new relationship. Must be "professional","confidential" or "private". Defaults to "professional", see the [support documentation](https://www.accelo.com/resources/help/guides/user/modules/companies-and-contacts/managers-and-relationships/#PrivateRelationships) for more information on manager relationships. |
 
-### Configuring the Response
+#### Configuring the Response
 This response may be configured and handled in the same way as [`GET /companies/{company_id}/managers`](#list-managers).
 
 
@@ -700,7 +700,7 @@ This response may be configured and handled in the same way as [`GET /companies/
 
 
 
-## Remove a Company
+### Remove a Company
 > Sample Request:  
 
 ```http
@@ -726,7 +726,7 @@ This request will remove a company, specified by its `company_id`, from the Acce
 
 
 
-## Remove a Manager
+### Remove a Manager
 > Sample Request:  
 
 ```http
@@ -754,7 +754,7 @@ This request returns a staff member, identified via the `relationship_id` of the
 |:-|:-|
 | **relationship_id** | The `relationship_id` of the manager to be removed. |
 
-### handling the Response
+#### handling the Response
 This response returns a list of manager (staff members) for the given company.
 
 
@@ -763,7 +763,7 @@ This response returns a list of manager (staff members) for the given company.
 
 
 
-## List Profile Field Values
+### List Profile Field Values
 > See the [profiles section](#retrieve-a-list-of-profile-values) for a sample request
 
 `GET /companies/{company_id}/profiles/values`
@@ -776,7 +776,7 @@ This request returns a list of [profile field values](#the-profile-value-object)
 
 
 
-## Update the value of a Profile Field
+### Update the value of a Profile Field
 > See the [profiles section](#update-a-profile-value-link) for a sample request  
 
 `PUT /companies/{company_id}/profiles/values/{profile_value_id}`
@@ -789,7 +789,7 @@ This request updates and returns a [profile field value](#the-profile-value-obje
 
 
 
-## List Available Progressions
+### List Available Progressions
 > See the [progressions section](#retrieve-a-list-of-available-progressions) for a sample request  
 
 `GET /companies/{company_id}/progressions`
@@ -802,7 +802,7 @@ This request returns a list of available [progressions](#progressions) for a [co
 
 
 
-## Auto Run a Progression
+### Auto Run a Progression
 > See the [progressions section](#run-a-status-update-using-a-given-progression) for a sample request  
 
 `[PUT|POST] /companies/{company_id}/progressions/{progression_id}/auto`
@@ -816,7 +816,7 @@ This request uses the given [progression](#progressions), specified by its `prog
 
 
 
-## List Profile Fields
+### List Profile Fields
 > See the [profiles section](#retrieve-a-list-of-profile-fields) for a sample request  
 
 `GET /companies/profiles/fields`
@@ -829,7 +829,7 @@ This request returns a list of [profile fields](#the-profile-field-object) avail
 
 
 
-## Create a Profile Field Value
+### Create a Profile Field Value
 > See the [profiles section](#create-a-profile-value-link) for a sample request
 
 `POST /companies/{company_id}/profiles/{profile_field_id}`
@@ -842,7 +842,7 @@ This request sets and returns a [profile value](#the-profile-value-object) for a
 
 
 
-## List Addresses
+### List Addresses
 > Sample Request:  
 
 `GET /companies/{company_id}/addresses`
@@ -855,7 +855,7 @@ This request returns a list of [addresses](#addresses) associated with a [compan
 
 
 
-## Create an Address
+### Create an Address
 > Sample Request:
 
 `POST /companies/{company_id}/addresses`
@@ -868,7 +868,7 @@ This request creates a [address](#addresses) against a [company](#the-company-ob
 
 
 
-## List Resource Collections
+### List Resource Collections
 > See the [resources (attachments) section](#retrieve-an-array-of-collections-for-an-object) for an example  
 
 `GET /companies/{company_id}/collections`
@@ -881,7 +881,7 @@ This request returns a list of [collections](#resources) against a [company](#th
 
 
 
-## Upload a Resource (Attachment)
+### Upload a Resource (Attachment)
 > See the [resources (attachments) section](#upload-a-resource-to-a-collection-of-an-object) for an example  
 
 `POST /companies/{company_id}/collections/{collection_id}/resources`

--- a/source/includes/endpoints/_contacts.md
+++ b/source/includes/endpoints/_contacts.md
@@ -1,11 +1,11 @@
-# Contacts
+## Contacts
 > Resource URI:  
 `/api/v0/contacts`
 
 Contacts are the Accelo entries for individual people. Contact entries Provide a central location where you can view all correspondence involving them. A contact is not directly associated with a company but it is with an affiliation. To create a contact against a given company, you should first create the contact and then the affiliation for the new contact against the company.
 
 
-## The Contact Object
+### The Contact Object
 The contact object contains the following fields and linked objects:
 
 | Field | Type | Description |
@@ -32,7 +32,7 @@ The contact object contains the following fields and linked objects:
 
 
 
-## Get Contact
+### Get Contact
 > Sample Request:  
 
 ```http
@@ -51,10 +51,10 @@ curl -X get \
 
 This request returns a single contact, identified by their `contact_id`.
 
-### Configuring the Request
+#### Configuring the Request
 This request supports requesting additional fields and linked objects from the [contact object](#the-contact-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will contain a single contact object with its default fields, and any additional fields requested through `_fields`.
 
 
@@ -63,7 +63,7 @@ The response will contain a single contact object with its default fields, and a
 
 
 
-## List Contacts
+### List Contacts
 > Sample Request:
 
 ```http
@@ -83,15 +83,15 @@ curl -X get \
 
 This request returns a list of contacts on the Accelo deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all of the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting any extra fields or linked objects from the [contacts object](#the-contact-object) object via the [`_fields`](#configuring-the-response-fields) parameter.
 
-#### Basic Filters
+##### Basic Filters
 This request supports [basic filters](#filters-basic-filters) over the following fields:
 
 | Field | Notes |
@@ -105,7 +105,7 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | username | |
 | contact_number | Filter over `phone`, `fax`, and `mobile`. |
 
-#### Date Filters
+##### Date Filters
 This request supports [date filters](#filters-date-filters) over the following fields:
 
 | Field |
@@ -113,7 +113,7 @@ This request supports [date filters](#filters-date-filters) over the following f
 | date_created |
 | date_modified |
 
-### Range Filters
+#### Range Filters
 This request supports [range filters](#filters-range-filters) over the following fields:
 
 | Field | Notes |
@@ -123,7 +123,7 @@ This request supports [range filters](#filters-range-filters) over the following
 | country | Filter by the `country_id` of the default affiliation of the contact. |
 
 
-### Searching
+#### Searching
 This request supports the use of the [`_search`](#configuring-the-response-searching) parameter over the following fields:
 
 | Field | Notes |
@@ -132,7 +132,7 @@ This request supports the use of the [`_search`](#configuring-the-response-searc
 | surname | |
 | email | |
 
-### Handling the Response
+#### Handling the Response
 This request will return a list of contacts containing their default fields and any additional field requested by `_fields`, and displayed according to any pagination parameters, filters or searches used.
 
 
@@ -141,7 +141,7 @@ This request will return a list of contacts containing their default fields and 
 
 
 
-## Count Contacts
+### Count Contacts
 > Sample Request:  
 
 ```http
@@ -171,7 +171,7 @@ This request will return a count of contacts in a list defined by any available 
 
 
 
-## List Recent Contacts
+### List Recent Contacts
 > Sample Request:  
 
 ```http
@@ -194,10 +194,10 @@ Equivalent request:
 
 This request returns a list of [contacts](#the-contact-object) on the Accelo deployment sorted by the most recently created, that is, in descending order of the their `date_created`.
 
-### Configuring the Response
+#### Configuring the Response
 This request accepts the same parameters and filters as [`GET /contacts`](#list-contacts), although it will always be ordered in descending order of `date_created`.
 
-### Handling the Response
+#### Handling the Response
 This request will return a list of contacts displayed according to any parameters used, and with their default fields plus and additional fields requested by `_fields`, and sorted in descending order of `date_created`.
 
 
@@ -206,7 +206,7 @@ This request will return a list of contacts displayed according to any parameter
 
 
 
-## List Recently Modified Contacts
+### List Recently Modified Contacts
 > Sample Request:  
 
 ```http
@@ -229,10 +229,10 @@ Equivalent request:
 
 This request returns a list of [contacts](#the-contact-object) on the Accelo deployment sorted by most recently modified, that is, in descending order of `date_modified`.
 
-### Configuring the Request
+#### Configuring the Request
 This request accepts the same parameters and filters as [`GET /contacts`](#list-contacts), although it will always be ordered in descending order of `date_modified`.
 
-### Handling the Response
+#### Handling the Response
 This request will return a list of contacts displayed according to any parameters used, and with their default fields plus and additional fields requested by `_fields`, and sorted in descending order of `date_modified`.
 
 
@@ -241,7 +241,7 @@ This request will return a list of contacts displayed according to any parameter
 
 
 
-## Update a Contact
+### Update a Contact
 > Sample Request:  
 
 ```http
@@ -262,7 +262,7 @@ curl -X get \
 
 This request updates and returns a [contact](#the-contact-object) in the Accelo deployment, identified by its `contact_id`. Recall that [affiliations](#affiliations) hold contact information (address, phone numbers etc.) for a contact, so if you wish to update these fields, or do not see the field you are after here, you may need to look at the [affiliation object](#the-affiliation-object).
 
-### Configuring the Contact
+#### Configuring the Contact
 This request allows updating the following fields in the [contact object](#the-contact-object):
 
 | Field | Type | Notes |
@@ -277,10 +277,10 @@ This request allows updating the following fields in the [contact object](#the-c
 | status | unsigned | Must point to a valid `status_id`, otherwise an invalid request will be returned. |
 | standing | string | Please only send one of `status` or `standing`, it both are sent the `standing` of the linked [status object](#statuses) will dominate anything sent through this field. |
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects through the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be the single, updated contact object, with its default fields and any additional fields requested through `_fields`.
 
 
@@ -289,7 +289,7 @@ The response will be the single, updated contact object, with its default fields
 
 
 
-## Create a Contact
+### Create a Contact
 > Sample Request:
 
 ```http
@@ -310,7 +310,7 @@ curl -X get \
 
 This request adds a new contact to the Accelo deployment and returns it. This is a sort of hybrid request, as it also creates an [affiliation](#affiliations) to associate the contact with a company.
 
-### Configuring the Contact
+#### Configuring the Contact
 This request accepts all fields from  the [`PUT \contacts`](#update-a-contact) request, with the `firstname` and `surname` fields being required, as well as the following fields from the [affiliation object](#affiliations-fields-and-linked-objects):
 
 | Field | Type | Notes |
@@ -326,10 +326,10 @@ This request accepts all fields from  the [`PUT \contacts`](#update-a-contact) r
 | communication | string | As in the [affiliation object](#affiliations-fields-and-linked-objects) |
 | invoice_method | string | As in the [affiliation object](#affiliations-fields-and-linked-objects) |
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked resources from the [contact object](#the-contact-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 This request will return the single new contact, with its default fields and any additional fields requested through `_fields`
 
 
@@ -338,7 +338,7 @@ This request will return the single new contact, with its default fields and any
 
 
 
-## Deactivate a Contact
+### Deactivate a Contact
 > Sample Request:  
 
 ```http
@@ -369,7 +369,7 @@ This request sets a contact on the Accelo deployment, identified by it's `contac
 
 
 
-## List Addresses
+### List Addresses
 > Sample Request:  
 
 ```http
@@ -395,7 +395,7 @@ This is simply the [`GET /{object}/{object_id}/addresses`](#list-addresses-again
 
 
 
-## Create an Address Against a Contact
+### Create an Address Against a Contact
 > Sample Request (TODO):
 
 `POST /contacts/{contacts_id}/addresses`
@@ -407,17 +407,17 @@ This request creates and returns an [address](#addresses) against a [contact](#t
 
 
 
-## Get Contact Status
+### Get Contact Status
 > Sample Request:  
 
 `GET /contacts/{contact_id}/status`
 
 This request returns the [status](#statuses) of a contact on the Accelo deployment, identified by their `contact_id`.
 
-### Configuring the Request
+#### Configuring the Request
 This request supports requesting additional fields and linked objects from the [status](#statuses) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 This request returns a single status with its default fields and any additional fields requested through `_fields`.
 
 
@@ -425,7 +425,7 @@ This request returns a single status with its default fields and any additional 
 
 
 
-## List Segmentations
+### List Segmentations
 > Sample Request:  
 
 `GET /contacts/{contact_id}/segmentations`
@@ -437,7 +437,7 @@ This request returns a list of [segmentations](#the-segmentation-object) for a [
 
 
 
-## List Profile Values
+### List Profile Values
 > See the [profiles section](#retrieve-a-list-of-profile-values) for a sample request
 
 `GET /contacts/{contact_id}/profiles/values`
@@ -450,7 +450,7 @@ This request returns a list of [profile values](#the-profile-value-object) of a 
 
 
 
-## Update a Profile Field Value
+### Update a Profile Field Value
 > See the [profiles section](#update-a-profile-value-link) for a sample request  
 
 `PUT /contacts/{contact_id}/profiles/values/{profile_value_id}`
@@ -463,7 +463,7 @@ This request updates and returns a [profile value](#the-profile-value-object), s
 
 
 
-## List Available Progressions
+### List Available Progressions
 > See the [progressions section](#retrieve-a-list-of-available-progressions) for a sample request
 
 `GET /contacts/{contact_id}/progressions`
@@ -476,7 +476,7 @@ This request returns a list of available [progressions](#the-progression-object)
 
 
 
-## Auto Run a Progression
+### Auto Run a Progression
 > See the [progressions section](#run-a-status-update-using-a-given-progression) for a sample request
 
 `PUT|POST /contacts/{contact_id}/progressions/{progression_id}/auto`
@@ -489,7 +489,7 @@ This request uses the given progression, specified by its `progression_id` to pr
 
 
 
-## List Profile Fields
+### List Profile Fields
 > See the [profiles section](#retrieve-a-list-of-profile-fields) for a sample request  
 
 `GET /contacts/profiles/fields`
@@ -502,7 +502,7 @@ This request returns a list of [profile fields](#the-profile-field-object) avail
 
 
 
-## Create a Profile Field Value
+### Create a Profile Field Value
 > See the [profiles section](#create-a-profile-value-link) for a sample request
 
 `POST /contacts/{contact_id}/profiles/fields/{profile_field_id}`
@@ -515,7 +515,7 @@ This request sets and returns a [profile value](#the-profile-value-object) for a
 
 
 
-## List Resource Collections
+### List Resource Collections
 > See the [resources (attachments) section](#retrieve-an-array-of-collections-for-an-object) for an example
 
 `GET /contacts/{contact_id}/collections`
@@ -528,7 +528,7 @@ This request returns a list of [collections](#resources-attachments) against a [
 
 
 
-## Upload a Resource (Attachment)
+### Upload a Resource (Attachment)
 > See the [resources (attachments) section](#upload-a-resource-to-a-collection-of-an-object) for an example  
 
 `POST /contacts/{contact_id}/collections/{collection_id}/resources`

--- a/source/includes/endpoints/_contracts.md
+++ b/source/includes/endpoints/_contracts.md
@@ -1,4 +1,4 @@
-# Contracts
+## Contracts
 > Resource URI:  
 `/api/v0/contracts`
 
@@ -6,7 +6,7 @@ Contracts (also known as retainers) are objects for managing recurring client wo
 
 The contracts model integrates flawlessly with the the [issues](#issues) and [jobs](#jobs-projects) modules so that you can even allocate work from those into a contract period. Contracts can also be linked to [service items](https://www.accelo.com/resources/help/guides/settings-and-configuration-guide/modules/billing-and-invoices/items/services/), allowing for easy handling of things like tax codes and ledger codes.
 
-## The Contract Object
+### The Contract Object
 > Example contract:
 
 ```json
@@ -70,7 +70,7 @@ The contract object contains the following fields and linked objects:
 | job | unsigned or object | The job the contract is against, if any. |
 | company | unsigned or object | The company the contract is against, if any. |
 
-### The Contract Period
+#### The Contract Period
 > Example contract period object:
 
 ```json
@@ -115,7 +115,7 @@ The contract period is a duration of time to track and invoice a contract. The `
 | contract_id | unsigned | The unique identifier of the contract the period belongs to. |
 
 
-### The Contract Type
+#### The Contract Type
 > Example contract type object:
 
 ```json
@@ -159,7 +159,7 @@ which contains the following additional fields:
 
 
 
-## Get Contract
+### Get Contract
 > Sample Request:  
 
 ```http
@@ -178,10 +178,10 @@ curl -X get \
 
 This request returns a single contract from the Accelo deployment, specified by its `contract_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [contract object](#the-contract-object) using the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-### handling the Response
+#### handling the Response
 The response will be a single [contract object](#the-contract-object), with its default fields and any additional fields requested by `_fields`.
 
 
@@ -189,7 +189,7 @@ The response will be a single [contract object](#the-contract-object), with its 
 
 
 
-## List Contracts
+### List Contracts
 > Sample Request:  
 
 ```http
@@ -208,15 +208,15 @@ curl -X get \
 
 This request returns a list of contracts from the Accelo deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting any extra fields or linked objects from the [contracts object](#the-contract-object) via the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-#### Basic Filters
+##### Basic Filters
 This request supports [basic filters](#filters-basic-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -232,7 +232,7 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | against_id | |
 | against_type | |
 
-#### Date Filters
+##### Date Filters
 This request supports [date filters](#filters-date-filters) over the following fields:
 
 | Filter Name |
@@ -242,7 +242,7 @@ This request supports [date filters](#filters-date-filters) over the following f
 | date_expired |
 | date_period_expires |
 
-#### Order Filters
+##### Order Filters
 This request supports [order filters](#filters-order-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -257,7 +257,7 @@ This request supports [order filters](#filters-order-filters) over the following
 | title | |
 | date_last_interacted | |
 
-#### Range Filters
+##### Range Filters
 this request supports [range filters](#filters-range-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -276,14 +276,14 @@ this request supports [range filters](#filters-range-filters) over the following
 | service_tax | Range by `service_tax_id` from the [service item](https://www.accelo.com/resources/help/guides/settings-and-configuration-guide/modules/billing-and-invoices/items/services/) linked to the contract, if any. |
 | service_ledger | Rage by `service_ledger_id`.from the [service item](https://www.accelo.com/resources/help/guides/settings-and-configuration-guide/modules/billing-and-invoices/items/services/) linked to the contract, if any. |
 
-#### Object Filters
+##### Object Filters
 This request supports the following [object filters](#filters-object-filters):
 
 | Filter Name | Description |
 |:-|:-|
 | against | Filter by contracts against these objects. |
 
-### handling the Response
+#### handling the Response
 The response will be a list of [contract objects](#the-contract-object) containing the default fields and any additional field requested by `_fields`, and displayed according to any pagination parameters or filters used.
 
 
@@ -291,7 +291,7 @@ The response will be a list of [contract objects](#the-contract-object) containi
 
 
 
-## Count Contracts
+### Count Contracts
 > Sample Request:
 
 ```http
@@ -319,7 +319,7 @@ This request will return a count of contracts in a list defined by any available
 
 
 
-## Get Contract Period
+### Get Contract Period
 > Sample Request:  
 
 ```http
@@ -338,10 +338,10 @@ curl -X get \
 
 This request returns a single [contract period](#the-contract-period) object from the Accelo deployment.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [contract period object](#the-contract-period) using the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-### Handling the Response
+#### Handling the Response
 This response will be a single contract period object, with its default fields and any additional fields requested via `_fields`.
 
 
@@ -349,7 +349,7 @@ This response will be a single contract period object, with its default fields a
 
 
 
-## List Contract Periods
+### List Contract Periods
 > Sample Request:  
 
 ```http
@@ -367,15 +367,15 @@ curl -X get \
 
 This request returns a list of [contract periods](#the-contract-period) for a contract, specified by its `contract_id`.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting extra fields or linked objects from the [contract_period object](#the-contract-period) using the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-#### Basic Filters
+##### Basic Filters
 This request supports [basic filters](#filters-basic-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -392,7 +392,7 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | contract | Filter over the `contract_id`. |
 | contract_budget |
 
-#### Date Filters
+##### Date Filters
 This request supports [date filters](#date-filters) over the following fields:
 
 | Filter Name |
@@ -402,7 +402,7 @@ This request supports [date filters](#date-filters) over the following fields:
 | date_expires |
 | date_closed |
 
-#### Range Filters
+##### Range Filters
 This request supports [range filters](#filters-range-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -414,7 +414,7 @@ This request supports [range filters](#filters-range-filters) over the following
 | budget | Range over the `budget_id`. |
 | service_item | Range over the `service_item_id`. |
 
-#### Order Filters
+##### Order Filters
 This request supports [order filtering](#filters-order-filters) over the following fields:
 
 | Filter Name |
@@ -425,7 +425,7 @@ This request supports [order filtering](#filters-order-filters) over the followi
 | date_expires |
 | date_closed |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [contract objects](#the-contract-object) containing the default fields and any additional fields requested by `_fields`, and displayed according to any pagination parameters or filters used.
 
 
@@ -433,7 +433,7 @@ The response will be a list of [contract objects](#the-contract-object) containi
 
 
 
-## List Contract Types
+### List Contract Types
 > Sample Request:  
 
 ```http
@@ -451,15 +451,15 @@ curl -X get \
 
 This request returns a list of contract types on the Accelo deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects from the [contract type object](#the-contract-type) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-#### Basic filters
+##### Basic filters
 This request supports [basic filters](#filters-basic-filters) over the following fields:
 
 | Field |
@@ -474,7 +474,7 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | service_tax_id |
 | service_ledger_id |
 
-#### Order Filters
+##### Order Filters
 This request supports [order filters](#filters-order-filters) over the following fields:
 
 | Field |
@@ -484,7 +484,7 @@ This request supports [order filters](#filters-order-filters) over the following
 | standing |
 | ordering |
 
-#### Range Filters
+##### Range Filters
 This request supports [range filters](#filters-range-filters) over the following fields:
 
 | Field |
@@ -492,21 +492,21 @@ This request supports [range filters](#filters-range-filters) over the following
 | id |
 | renew_days |
 
-#### Empty Filters
+##### Empty Filters
 This request supports [empty filters](#filters-empty-filters) over the following fields:
 
 | Field |
 |:-|
 | title |
 
-#### Searching
+##### Searching
 This request the use of the [`_search`](#configuring-the-response-searching) parameter to search over the following fields:
 
 | Field |
 |:-|
 | title |
 
-### Handling the Response
+#### Handling the Response
 This request will return a list of contract types containing the default fields and any additional fields request by `_fields`, and displayed according to any pagination parameters, filters, or searches used.
 
 
@@ -514,7 +514,7 @@ This request will return a list of contract types containing the default fields 
 
 
 
-## Count Contract Types
+### Count Contract Types
 > Sample Request:  
 
 ```http
@@ -541,7 +541,7 @@ This request returns a count of [contract types](#the-contract-type) in a list d
 
 
 
-## Get Contract Type
+### Get Contract Type
 > Sample Request:  
 
 ```http
@@ -559,17 +559,17 @@ curl -X get \
 
 This request returns a single [contract type object](#the-contract-type) identified by its `contract_type_id`.
 
-### Configuring the Request
+#### Configuring the Request
 This request supports requesting extra fields or objects from the [contract type object](#the-contract-type) through the `_fields` parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will contain the single contract type with its default fields, and any additional fields requested through `_fields`.
 
 
 
 
 
-## Close a Contract Period (Beta)
+### Close a Contract Period (Beta)
 > Sample Request:
 
 ```http
@@ -594,7 +594,7 @@ This request closes and returns a [contract period](#the-contract-period), see t
 
 
 
-## Reopen a Contract Period (Beta)
+### Reopen a Contract Period (Beta)
 > Sample Request:
 
 ```http
@@ -617,7 +617,7 @@ This request reopens and returns a previously close [contract period](#the-contr
 
 
 
-## List Available Progressions
+### List Available Progressions
 > See the [progressions section](#retrieve-a-list-of-available-progressions) for a sample request
 
 `GET /contracts/{contract_id}/progressions`
@@ -629,7 +629,7 @@ This request returns a list of available [progressions](#the-progression-object)
 
 
 
-## Auto Run a Progression
+### Auto Run a Progression
 > See the [progressions section](#run-a-status-update-using-a-given-progression) for a sample request
 
 `[POST|PUT] /contracts/{contract_id}/progressions/{progression_id}/auto`
@@ -641,7 +641,7 @@ This request uses the given progression, specified by its `progression_id` to pr
 
 
 
-## List Resource Collections
+### List Resource Collections
 > See the [resources (attachments) section](#retrieve-an-array-of-collections-for-an-object) for an example  
 
 `GET /companies/{company_id}/collections`
@@ -653,7 +653,7 @@ This request returns a list of [collections](#resources) against a [company](#th
 
 
 
-## Upload a Resource (Attachment)
+### Upload a Resource (Attachment)
 > See the [resources (attachments) section](#upload-a-resource-to-a-collection-of-an-object) for an example   
 
 `POST /companies/{company_id}/collections/{collection_id}/resources`
@@ -665,7 +665,7 @@ This request uploads a [resource](#resources) to a collection, specified by its 
 
 
 
-## List Extension Fields
+### List Extension Fields
 > See the [extension section](#retrieve-a-list-of-extension-fields) for an example
 
 `GET /contracts/extensions/fields`
@@ -677,7 +677,7 @@ This request returns a list of [extension fields](#the-extension-field-object) a
 
 
 
-## List Extension Field Values
+### List Extension Field Values
 > See the [extension section](#retrieve-a-list-of-extension-field-values) for an example     
 
 `GET /contracts/{contract_id}/extensions/values`
@@ -689,7 +689,7 @@ This request returns a list of [extension values](#the-extension-value-object) f
 
 
 
-## Update an Extension Field Value
+### Update an Extension Field Value
 > See the [extension section](#update-an-extension-value) for an example    
 
 `PUT /contracts/{contract_id}/extensions/values/{extension_value_id}`
@@ -700,7 +700,7 @@ This request updates the value of an [extension field value](#the-extension-valu
 
 
 
-## Set an Extension Value
+### Set an Extension Value
 > See the [extension section](#create-an-extension-value) for an example  
 
 `POST /contracts/{contract_id}/extensions/fields/{extension_field_id}`

--- a/source/includes/endpoints/_divisions.md
+++ b/source/includes/endpoints/_divisions.md
@@ -1,10 +1,10 @@
-# Divisions
+## Divisions
 > Resource URI:  
 `/api/v0/divisions`
 
 Divisions allow you manage contacts, companies, and staff under different details, rates, or identities. See the [support documentation](https://www.accelo.com/resources/help/faq/divisions/) for more information.
 
-## The Division Object (Beta)
+### The Division Object (Beta)
 > Sample division JSON object:
 
 ```json
@@ -30,7 +30,7 @@ The division object contains the following:
 
 
 
-## Get Division (Beta)
+### Get Division (Beta)
 > Sample request:
 
 ```shell
@@ -53,17 +53,17 @@ _fields=standing
 
 This request returns a division specified by its unique identifier.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [division object](#the-division-object-beta) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be a single division with its default fields and any additional fields requested through `_fields`.
 
 
 
 
 
-## List Divisions (Beta)
+### List Divisions (Beta)
 > Sample request:
 
 ```shell
@@ -85,12 +85,12 @@ Content-Type: application/x-www-form-urlencoded
 
 This request returns a list of [divisions](#the-division-object-beta) on the deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all of the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Basic Filters
+##### Basic Filters
 This request supports the following [basic filters](#filters-basic-filters):
 
 | Filter Name |
@@ -99,7 +99,7 @@ This request supports the following [basic filters](#filters-basic-filters):
 | title |
 | standing |
 
-#### Order Filters
+##### Order Filters
 This request supports [order filters](#filters-order-filters) over the following fields:
 
 | Field |
@@ -107,21 +107,21 @@ This request supports [order filters](#filters-order-filters) over the following
 | id |
 | ordering |
 
-#### Searching
+##### Searching
 This request supports the use of the [`_search`](#configuring-the-response-searching) parameter to search over the following fields:
 
 | Field |
 |:-|
 | title |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [divisions](#the-division-object-beta) with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters, filters, or searches used.
 
 
 
 
 
-## Count Divisions (Beta)
+### Count Divisions (Beta)
 > Sample request:
 
 ```shell

--- a/source/includes/endpoints/_expenses.md
+++ b/source/includes/endpoints/_expenses.md
@@ -1,10 +1,10 @@
-# Expenses
+## Expenses
 > Resource URI:  
 `/api/v0/expenses`
 
 In the Accelo API, expenses are against objects, such as [jobs](#jobs), or [issues](#issues). For example, an expense may be the cost of some training materials, or the cost of travel expenses for a staff member.
 
-## The Expenses Object
+### The Expenses Object
 > Sample expense:
 
 ```json
@@ -58,7 +58,7 @@ The expense object contains the following fields and linked objects:
 | activity | unsigned or object | The [activity object](#expenses) of the activity against the expense. |
 | resource | unsigned or object | The [resource object](#resources-attachments) (attachment) associated with the expense. |
 
-### The Expense Type
+#### The Expense Type
 > Sample expense type:
 
 ```json
@@ -93,7 +93,7 @@ which contains the following additional fields:
 
 
 
-## Get Expense
+### Get Expense
 > Sample Request:  
 
 ```http
@@ -112,10 +112,10 @@ curl -X get \
 
 This request returns a single [expense object](#the-expense-object) specified by it's `expense_id`.
 
-### Configuring the Request
+#### Configuring the Request
 This request supports requesting additional objects and fields from the [expenses object](#the-expense-object) using the `_fields` parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-### Handling the Response
+#### Handling the Response
 The response will be a single expense object with its default fields and any additional fields requesting through `_fields`.
 
 
@@ -124,7 +124,7 @@ The response will be a single expense object with its default fields and any add
 
 
 
-## List Expenses
+### List Expenses
 > Sample Request:
 
 ```http
@@ -143,15 +143,15 @@ curl -X get \
 
 This request returns a list of expenses on the Accelo deployment.
 
-### Configuring the Request
+#### Configuring the Request
 
-#### Pagination
+##### Pagination
 This request supports all the [pagination](#configuring-the-response-pagination) parameters:
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request also supports requesting extra fields or linked objects of the [expenses object](#the-expenses-object) using the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-#### Basic Filters
+##### Basic Filters
 This request supports [basic filters](#filters-basic-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -165,14 +165,14 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | against_type ||
 | against_id ||
 
-#### Date Filters
+##### Date Filters
 This request supports [date filters](#filters-date-filters) over the following fields:
 
 | Filter Name |
 |:-|
 | date_incurred |
 
-#### Order Filters
+##### Order Filters
 This requesting supports [order filters](#filters-order-filters) over the following fields:
 
 | Filter Name |
@@ -182,7 +182,7 @@ This requesting supports [order filters](#filters-order-filters) over the follow
 | title |
 | standing |
 
-#### Range Filters
+##### Range Filters
 This request supports [range filters](#filters-range-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -196,21 +196,21 @@ This request supports [range filters](#filters-range-filters) over the following
 | unit_cost |
 | cost | Range over the total cost, that is `unit_cost` times `quantity`. |
 
-#### Object Filters
+##### Object Filters
 This request supports the following [object filters](#filters-object-filters):
 
 | Filter | Description |
 |:-|:-|
 | against | Filter by expenses against these objects. |
 
-#### Searching
+##### Searching
 This request supports the use of the [`_search`](#configuring-the-response-searching) parameter to search over the following fields:
 
 | Field |
 |:-|
 | title |
 
-### handling the Response
+#### handling the Response
 This request will return a list of expenses containing the default fields and any additional fields request by `_fields`, and displayed according to any pagination parameters, filters, or searches used.
 
 
@@ -219,7 +219,7 @@ This request will return a list of expenses containing the default fields and an
 
 
 
-## Count Expenses
+### Count Expenses
 > Sample Request:
 
 ```http
@@ -248,7 +248,7 @@ This request will return a count of expenses in a list defined by any available 
 
 
 
-## Get Expense Type
+### Get Expense Type
 > Sample Request:  
 
 ```http
@@ -267,10 +267,10 @@ curl -X get \
 
 This request returns a single [expenses type](#the-expense-type) object, specified by its `type_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting extra fields and linked objects from the [expenses type](#the-expense-type) object using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### handling the Response
+#### handling the Response
 The response will be a single [expense type](#the-expense-type) object with its default fields, and any additional fields requested through `_fields`.
 
 
@@ -279,7 +279,7 @@ The response will be a single [expense type](#the-expense-type) object with its 
 
 
 
-## List Expense Types
+### List Expense Types
 > Sample Request:  
 
 ```http
@@ -298,15 +298,15 @@ curl -X get \
 
 This request returns a list of [types of expenses](#the-expense-type) on the Accelo deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all the [pagination](#configuring-the-response-pagination) parameters:
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting extra fields and linked objects from the [expense type](#the-expense-type) object using the [`_fields`](#configuring-the-response-fields) parameter.
 
-#### Basic Filters
+##### Basic Filters
 This request supports [basic filters](#filters-basic-filters) over the following fields:
 
 | Filter Name |
@@ -317,7 +317,7 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | tax_id |
 
 
-#### Order Filters
+##### Order Filters
 This request supports [order filters](#filters-order-filters) over the following fields:
 
 | Filter Name |
@@ -326,28 +326,28 @@ This request supports [order filters](#filters-order-filters) over the following
 | title |
 | standing |
 
-#### Range Filters
+##### Range Filters
 This request supports [range filters](#filters-range-filters) over the following fields:
 
 | Filter Name |
 |:-|
 | id |
 
-#### Empty Filters
+##### Empty Filters
 This request supports [empty filters](#filters-empty-filters) over the following fields:
 
 | Field |
 |:-|
 | title |
 
-#### Searching
+##### Searching
 This request the use of the [`_search`](#configuring-the-response-searching) parameter to search over the following fields:
 
 | Field |
 |:-|
 | title |
 
-### handling the Response
+#### handling the Response
 The response will contain a list of [expense types](#the-expense-type) with their default fields, and any additional fields requested through `_fields`, and displayed according to any pagination parameters, filters, or searches used.
 
 
@@ -356,7 +356,7 @@ The response will contain a list of [expense types](#the-expense-type) with thei
 
 
 
-## Count Expense Types
+### Count Expense Types
 > Sample Request:  
 
 ```http
@@ -385,7 +385,7 @@ This request returns a count of [expense types](#the-expense-type) in a list def
 
 
 
-## Update an Expense
+### Update an Expense
 > Sample Request:  
 
 ```http
@@ -406,7 +406,7 @@ curl -X get \
 
 This request updates and returns an [expense](#the-expense-object), identified by its `expense_id`.
 
-### Configuring the Expense
+#### Configuring the Expense
 The following fields from the [expense object](#the-expense-object) may be updated through this request:
 
 | Field Name |
@@ -420,10 +420,10 @@ The following fields from the [expense object](#the-expense-object) may be updat
 | date_incurred |
 | resource_id |
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [expense object](#the-expense-object) using the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-### handling the Response
+#### handling the Response
 The response will be the single updated [expense object](#the-expense-object) with its default fields, and any additional fields requested through `_fields`.
 
 
@@ -432,7 +432,7 @@ The response will be the single updated [expense object](#the-expense-object) wi
 
 
 
-## Create an Expense
+### Create an Expense
 > Sample Request:  
 
 ```http
@@ -453,7 +453,7 @@ curl -X get \
 
 This request creates and returns an [expense object](#the-expense-object).
 
-### Configuring the Expense
+#### Configuring the Expense
 The following fields from the [expense object](#the-expense-object) may be set with this request:
 
 | Field Name | Notes |
@@ -471,10 +471,10 @@ The following fields from the [expense object](#the-expense-object) may be set w
 | file | Allows you to upload a file with the expense (i.e. a receipt in the form of an image or PDF). If this value is set then it must be POSTed with **multipart/form-data**. |
 | resource_id | The unique identifier of a [resource (attachment)](#resources-attachments) to be sent with the expense. **Note**: you may only pass one of `resource_id` or `file`.|
 
-### Configuring the Response
+#### Configuring the Response
 This response supports requesting extra fields and linked objects from the [expenses object](#the-expense-object) through the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-### Handling the Response
+#### Handling the Response
 The request will return the single new [expense object](#the-expense-object) with its default fields, and any additional fields requested through `_fields`.
 
 
@@ -483,7 +483,7 @@ The request will return the single new [expense object](#the-expense-object) wit
 
 
 
-## Delete an Expense
+### Delete an Expense
 > Sample Request:  
 
 ```http
@@ -509,7 +509,7 @@ This request removes an expense from the deployment. It takes no parameters and 
 
 
 
-## List Available Progressions
+### List Available Progressions
 > See the [progressions section](#retrieve-a-list-of-available-progressions) for a sample request
 
 `GET /companies/{expense_id}/progressions`
@@ -521,7 +521,7 @@ This request returns a list of available [progressions](#progressions) for an [e
 
 
 
-## Auto Run a Progression
+### Auto Run a Progression
 > See the [progressions section](#run-a-status-update-using-a-given-progression) for a sample request
 
 `[PUT|POST] /companies/{expense_id}/progressions/{progression_id}/auto`

--- a/source/includes/endpoints/_extensions.md
+++ b/source/includes/endpoints/_extensions.md
@@ -1,4 +1,4 @@
-# Extensions (Custom Fields)
+## Extensions (Custom Fields)
 <a name="extensions"></a>
 
 > Resource URI:  
@@ -13,7 +13,7 @@ Extensions, also known as Custom Fields, are similar to [profiles](#profiles). T
 
 Similarly to [profiles](#profiles), extensions are described by [extension fields](#the-extension-field-object) and [extension values](#the-extension-value-object), which store the information of values of an extension field.
 
-## The Extension Field Object
+### The Extension Field Object
 > Sample extension field:
 
 ```json
@@ -56,7 +56,7 @@ These are objects describing the custom field on the deployment, they contain th
 | lookup_type | string | When `field_type` is lookup, this will contain the type of object for the lookup. |
 | information | string | Any extra information about the extension. |
 
-## The Extension Value Object
+### The Extension Value Object
 > Example extension field value:
 
 ```json
@@ -105,7 +105,7 @@ These describe the value of a given [extension field](#the-extension-field-objec
 
 
 
-## List Extension Fields
+### List Extension Fields
 <a name="retrieve-a-list-of-extension-fields"></a>
 > Sample Request:  
 
@@ -125,14 +125,14 @@ curl -X get \
 
 This request request returns a list of [extension fields](#the-extension-field-object) available for the given object
 
-### Configuring the Response
-#### Pagination
+#### Configuring the Response
+##### Pagination
 This request supports all of the [pagination](#configuring-the-response-pagination) parameters
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects from the [extension field object](#the-extension-field-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### handling the Response
+#### handling the Response
 The response will be a list of [extension field object](#the-extension-field-object) with their default fields, and any additional fields requested using `_fields.`
 
 
@@ -141,7 +141,7 @@ The response will be a list of [extension field object](#the-extension-field-obj
 
 
 
-## List Extension Field Values
+### List Extension Field Values
 <a name="retrieve-a-list-of-extension-field-values"></a>
 > Sample Request:  
 
@@ -161,14 +161,14 @@ curl -X get \
 
 This request returns a list of [extension field values](#the-extension-value-object) for the given `object` identified by its `object_id`.
 
-### Configuring the Response
-#### Pagination
+#### Configuring the Response
+##### Pagination
 This request supports all of the [pagination](#configuring-the-response-pagination) parameters
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects from the [extension value object](#the-extension-value-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [extension field values](#the-extension-value-object) with their default fields, and any additional fields requested through `_fields`.
 
 
@@ -177,7 +177,7 @@ The response will be a list of [extension field values](#the-extension-value-obj
 
 
 
-## Update an Extension Field Value
+### Update an Extension Field Value
 <a name="update-an-extension-value"></a>
 
 > Sample Request, here we are updating the value of an extension field value of "jobs/56" to be "international":  
@@ -203,7 +203,7 @@ curl -X put \
 
 This request updates and returns a [extension values](#the-extension-value-object), specified by its `extension_value_id`, of a particular object, specified by its `object_id`, of a particular type, specified by `object`.
 
-### Configuring the Extension Value
+#### Configuring the Extension Value
 This request updates the `value` of an extension value, since this object is dynamic the field we send will depend on the type of `value`:
 
 | Field | Type | Description |
@@ -214,10 +214,10 @@ This request updates the `value` of an extension value, since this object is dyn
 | value_type | string | If 'field_type' is "lookup", update the `value_type` with this string.  |
 | value | string | If `field_type` is none of the above, update the `value` with this string. |
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [extension value object](#the-extension-value-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### handling the Response
+#### handling the Response
 This request will return the single, updated [extension value object](#the-extension-value-object) with its default fields, and any additional fields requesting through `_fields`.
 
 
@@ -226,7 +226,7 @@ This request will return the single, updated [extension value object](#the-exten
 
 
 
-## Set an Extension Field Value
+### Set an Extension Field Value
 <a name="create-an-extension-value"></a>
 > Sample Request, here we are setting a value for an extension field value for "jobs/12":  
 
@@ -251,11 +251,11 @@ curl -X put \
 
 This request sets and returns an [extension value](#the-extension-value-object). for an extension field, specified by its `extension_field_id`. The object whose profile field is to be updated is identified by `object` and `object_id`
 
-### Configuring the Extension Value
+#### Configuring the Extension Value
 This request accepts the same fields as the [previous request](#update-an-extension-value), that is, it takes only the relevant value field(s). These fields are required for this request.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [extension value object](#the-extension-value-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### handling the Response
+#### handling the Response
 This request will return the newly created [extension value object](#the-extension-value-object) with its default fields and any additional fields requested using `_fields`.

--- a/source/includes/endpoints/_filters.md
+++ b/source/includes/endpoints/_filters.md
@@ -1,4 +1,4 @@
-# Filters
+## Filters
 > Resource URI:  
 `/api/v0/filters`
 
@@ -18,7 +18,7 @@ Filters are available on the Accelo deployment that allow you to search through 
 * [Tasks](#tasks)
 
 
-## The Filter Object
+### The Filter Object
 > Example filter object:
 
 ```json
@@ -49,7 +49,7 @@ This object stores information on the filter, such as who created it, and which 
 
 
 
-## List Filters
+### List Filters
 > Sample Request:
 
 ```http
@@ -68,15 +68,15 @@ curl -X get \
 
 This request returns a list of saved [filters](#the-filter-object) on the Accelo deployment. This list will not include any filters created by other users which have not been shared.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports the standard [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects through the [`fields`](#configuring-the-response-fields) parameter.
 
-#### Basic Filters
+##### Basic Filters
 This request supports [basic filters](#filters-basic-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -86,7 +86,7 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | staff | Filter by `staff_id`. |
 | object_type | |
 
-#### Order Filters
+##### Order Filters
 This request supports [order filters](#filters-order-filters) over the following fields:
 
 | Filter Name |
@@ -95,14 +95,14 @@ This request supports [order filters](#filters-order-filters) over the following
 | title |
 | shared |
 
-#### Range Filters
+##### Range Filters
 This request supports [range filters](#filters-range-filters) over the following fields:
 
 | Filter Name |
 |:-|
 | id |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [filter objects](#the-filter-object) containing their default values, and any additional values requested through `_fields`, and displayed according to any pagination parameters or filters used.
 
 
@@ -111,7 +111,7 @@ The response will be a list of [filter objects](#the-filter-object) containing t
 
 
 
-## List Filters Against an Object
+### List Filters Against an Object
 > Sample Request:
 
 ```http
@@ -130,15 +130,15 @@ curl -X get \
 
 This request returns a list of [filters](#the-filter-object) saved against a particular object, specified by `object`. This list will not include any filters created by other users which have not been shared.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports the standard [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects through the [`_fields`](#configuring-the-response-fields) parameter.
 
-#### Basic Filters
+##### Basic Filters
 This request supports [basic filters](#filters-basic-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -147,7 +147,7 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | shared | |
 | staff | Filter by `staff_id`. |
 
-#### Order Filters
+##### Order Filters
 This request supports [order filters](#filters-order-filters) over the following fields:
 
 | Filter Name |
@@ -156,14 +156,14 @@ This request supports [order filters](#filters-order-filters) over the following
 | title |
 | shared |
 
-#### Range Filters
+##### Range Filters
 This request supports [range filters](#filters-range-filters) over the following fields:
 
 | Filter Name |
 |:-|
 | id |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [filter objects](#the-filter-object) saved against the given object, containing their default values, and any additional values requested through `_fields`, and displayed according to any pagination parameters or filters used.
 
 
@@ -172,7 +172,7 @@ The response will be a list of [filter objects](#the-filter-object) saved agains
 
 
 
-## Update a Filter
+### Update a Filter
 > Sample Request:
 
 ```http
@@ -191,7 +191,7 @@ curl -X get \
 
 This request allows you to update a saved [filter](#the-filter-object) on the Accelo deployment.
 
-### Configuring the Filter
+#### Configuring the Filter
 The following fields from the [filter object](#the-filter-object) may be updated with this request:
 
 | Filter Name |
@@ -199,10 +199,10 @@ The following fields from the [filter object](#the-filter-object) may be updated
 | title |
 | shared |
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [filter object](#the-filter-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### handling the Response
+#### handling the Response
 The response will be the single, updated [filter object](#the-filter-object) containing its default fields, and any additional fields requested via `_fields`
 
 
@@ -211,7 +211,7 @@ The response will be the single, updated [filter object](#the-filter-object) con
 
 
 
-## Run a Filter
+### Run a Filter
 > Sample Request:
 
 ```http
@@ -230,17 +230,17 @@ curl -X get \
 
 This request allows you to run, and see the output of, a [filter](#the-filter-object).
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request accepts the following [pagination](#configuring-the-response-pagination) parameters:
 
 | Filter Name |
 |:-|
 | _limit |
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects through the [`_fields`](#configuring-the-response-fields) parameter. This parameter will be applied to whatever object the filter is used for, that is, the `object_type`.
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of objects that are of type `object_type`, with their default fields, and any additional fields requested through `_fields`, and displayed according to the value of `_limit` set.

--- a/source/includes/endpoints/_groups.md
+++ b/source/includes/endpoints/_groups.md
@@ -1,7 +1,7 @@
-# Groups
+## Groups
 Groups allow you to categorize your staff for bulk assignments and access controls. See the [support documentation](https://www.accelo.com/resources/help/faq/user-permissions-and-settings/managing-user-groups/) for more information.
 
-## The Group Object (Beta)
+### The Group Object (Beta)
 > Sample JSON group object:
 
 ```json
@@ -27,7 +27,7 @@ The group object contains the following:
 
 
 
-## Get Group (Beta)
+### Get Group (Beta)
 > Sample Request
 
 ```shell
@@ -50,10 +50,10 @@ _fields=standing
 
 This request returns a [group](#the-group-object-beta) specified by its unique `group_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [group object](#the-group-object-beta) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be a single group with its default fields and any additional fields requested through `_fields`.
 
 
@@ -61,7 +61,7 @@ The response will be a single group with its default fields and any additional f
 
 
 
-## List Groups (Beta)
+### List Groups (Beta)
 > Sample Request
 
 ```shell
@@ -86,15 +86,15 @@ _filters=parent_id(3)
 
 This request returns a list of [groups](#the-group-object-beta) on the deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all of the [pagination parameters](#configuring-the-response-pagination).
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects from the [group object](#the-group-object-beta) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-#### Basic Filters
+##### Basic Filters
 This request supports [basic filters](#filters-basic-filters) over the following fields:
 
 | Field | Description |
@@ -103,20 +103,20 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | title |
 | staff_id | Filter group(s) to which the [staff member](#staff) with this id belongs. |
 
-#### Searching
+##### Searching
 This request supports the [`_search`](#configuring-the-response-searching) parameter to search over the following fields:
 
 | Field |
 |:-|
 | title |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [group objects](#the-group-object-beta) with the default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters, filters, or searches used.
 
 
 
 
-## Count Groups (Beta)
+### Count Groups (Beta)
  Sample Request
 
 ```shell

--- a/source/includes/endpoints/_holidays.md
+++ b/source/includes/endpoints/_holidays.md
@@ -1,7 +1,7 @@
-# Holidays (Beta)
+## Holidays (Beta)
 A user's holidays are available through the API as the "holiday" object. 
 
-## The Holiday Object (Beta)
+### The Holiday Object (Beta)
 > Sample holiday:
 
 ```json
@@ -33,7 +33,7 @@ The holiday object contains the following:
 
 
 
-## Get Holiday (Beta)
+### Get Holiday (Beta)
 
 ```http
 GET /holidays/{holiday_id} HTTP/1.1
@@ -51,10 +51,10 @@ curl -X GET \
 
 This request returns a single [holiday](#the-holiday-object-beta), specified by its `holiday_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [holiday object](#the-holiday-object-beta) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be a single holiday with its default fields and any additional fields requested through `_fields`.
 
 
@@ -62,7 +62,7 @@ The response will be a single holiday with its default fields and any additional
 
 
 
-## List Holidays (Beta)
+### List Holidays (Beta)
 
 ```http
 GET /holidays/ HTTP/1.1
@@ -80,15 +80,15 @@ curl -X GET \
 
 This request returns a list of [holidays](#the-holiday-object-beta).
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all the standard [pagination parameters](#configuring-the-response-pagination).
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects from the [holiday object](#the-holiday-object-beta) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-#### Basic Filters
+##### Basic Filters
 This request supports the following [basic filters](#filters-basic-filters):
 
 | Filter |
@@ -96,7 +96,7 @@ This request supports the following [basic filters](#filters-basic-filters):
 | id |
 | staff_id |
 
-#### Date Filters
+##### Date Filters
 This request supports [date filters](#filters-date-filters) over the following fields:
 
 | Field |
@@ -104,7 +104,7 @@ This request supports [date filters](#filters-date-filters) over the following f
 | date_start |
 | date_end|
 
-#### Range Filters
+##### Range Filters
 This request supports [range filters](#filters-range-filters) over the following fields:
 
 | Field |
@@ -115,7 +115,7 @@ This request supports [range filters](#filters-range-filters) over the following
 | date_end |
 | duration_seconds |
 
-#### Order Filters
+##### Order Filters
 This request supports [order filters](#filters-order-filters) over the following fields:
 
 | Field |
@@ -127,7 +127,7 @@ This request supports [order filters](#filters-order-filters) over the following
 | title |
 | duration |
 
-#### Empty Filters
+##### Empty Filters
 This request supports the following [empty filters](#filters-empty-filters):
 
 | Filter |
@@ -135,14 +135,14 @@ This request supports the following [empty filters](#filters-empty-filters):
 | date_end |
 | duration_seconds |
 
-#### Searching
+##### Searching
 This request supports the [`_search`](#configuring-the-response-searching) to search over the following fields:
 
 | Field |
 |:-|
 | title |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [holidays](#the-holiday-object-beta) with their default fields and any additional fields requested through `_fields`, and displaying according to any pagination parameters, filters, or searches used.
 
 
@@ -150,7 +150,7 @@ The response will be a list of [holidays](#the-holiday-object-beta) with their d
 
 
 
-## Count Holidays (Beta)
+### Count Holidays (Beta)
 
 ```http
 GET /holidays/count HTTP/1.1
@@ -177,7 +177,7 @@ This request returns a count of [holidays](#the-holiday-object-beta) in a list d
 
 
 
-## Update Holiday (Beta)
+### Update Holiday (Beta)
 
 ```http
 PUT /holidays/{holiday_id} HTTP/1.1
@@ -195,7 +195,7 @@ curl -X PUT \
 
 This request updates and returns a [holiday](#the-holiday-object-beta) specified by its `holiday_id`.
 
-### Configuring the Holiday
+#### Configuring the Holiday
 
 The following fields from the [holiday object](#the-holiday-object-beta) may be updated through this request, (date fields may be sent as unix timestamps, or in ISO8601 format):
 
@@ -209,10 +209,10 @@ The following fields from the [holiday object](#the-holiday-object-beta) may be 
 
 **Note:** you may only update one of `date_end` or `duration_seconds`.
 
-### Configuring the Response
+#### Configuring the Response
 The response may be configuring as per [Get Holiday](#get-holiday-beta)
 
-### Handling the Response
+#### Handling the Response
 The response will be the single, updated holiday with its default fields and any additional fields requested through `_fields`.
 
 
@@ -220,7 +220,7 @@ The response will be the single, updated holiday with its default fields and any
 
 
 
-## Create Holiday (Beta)
+### Create Holiday (Beta)
 
 ```http
 POST /holidays/ HTTP/1.1
@@ -238,7 +238,7 @@ curl -X POST \
 
 This request creates and returns a [holiday](#the-holiday-object-beta).
 
-### Configuring the Holiday
+#### Configuring the Holiday
 The following fields may be set through this request, (date fields may be sent as unix timestamps, or in ISO8601 format):
 
 | Field |
@@ -251,10 +251,10 @@ The following fields may be set through this request, (date fields may be sent a
 
 **Note:** only one of `date_end` or `duration_seconds` is required; both cannot be sent.
 
-### Handling the Response
+#### Handling the Response
 The response may be configuring as per [Get Holiday](#get-holiday-beta)
 
-### Handling the Response
+#### Handling the Response
 The response will be the new holiday with its default fields and any additional fields requested through `_fields`.
 
 
@@ -262,7 +262,7 @@ The response will be the new holiday with its default fields and any additional 
 
 
 
-## Delete Holiday (Beta)
+### Delete Holiday (Beta)
 
 ```http
 DELETE /holidays/{holiday_id} HTTP/1.1

--- a/source/includes/endpoints/_invoices.md
+++ b/source/includes/endpoints/_invoices.md
@@ -1,10 +1,10 @@
-# Invoices
+## Invoices
 > Resource URI:  
 `/api/v0/invoices`
 
 These are invoices for any work done. See the [support documentation](https://www.accelo.com/resources/help/guides/user/modules/billing-and-invoices/invoices/) for more information on invoices.
 
-## The Invoice Object
+### The Invoice Object
 > Example invoice object:
 
 ```json
@@ -55,7 +55,7 @@ The invoice object contains the following:
 | creator_id | unsigned | The unique identifier for the staff member who created the deployment. |
 | created_by | unsigned or object | The staff member who created the invoice. |
 
-### The Line Item (Beta)
+#### The Line Item (Beta)
 > Example line item:
 
 ```json
@@ -98,7 +98,7 @@ Each line in an invoice is described by a line item object. This object contains
 
 
 
-## Get Invoice
+### Get Invoice
 > Sample Request:
 
 ```http
@@ -117,10 +117,10 @@ curl -X get \
 
 This request returns a single [invoice](#the-invoice-object), specified by its `invoice_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [invoice object](#the-invoice-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be the single requested [invoice](#the-invoice-object) with its default fields and any additional fields requested through `_fields`.
 
 
@@ -129,7 +129,7 @@ The response will be the single requested [invoice](#the-invoice-object) with it
 
 
 
-## List Invoices
+### List Invoices
 > Sample Request:
 
 ```http
@@ -148,15 +148,15 @@ curl -X get \
 
 This request returns a list of [invoices](#the-invoice-object) on the deployment.
 
-### Configuring the Request
+#### Configuring the Request
 
-#### Pagination
+##### Pagination
 This request accepts all the standard [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects using the [`_fields`](#configuring-the-response-fields) parameter.
 
-#### Basic Filters
+##### Basic Filters
 This request supports [basic filters](#filters-basic-filters) over the following fields:
 
 | Filter Name |
@@ -164,7 +164,7 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | id |
 | invoice_number |
 
-#### Date Filters
+##### Date Filters
 This request supports [date filters](#filters-date-filters) over the following fields:
 
 | Filter Name |
@@ -173,7 +173,7 @@ This request supports [date filters](#filters-date-filters) over the following f
 | date_due |
 | date_modified |
 
-#### Order Filters
+##### Order Filters
 This request supports [order filters](#filters-order-filters) over the following fields:
 
 | Filter Name |
@@ -183,7 +183,7 @@ This request supports [order filters](#filters-order-filters) over the following
 | date_due |
 | date_modified |
 
-#### Range Filters
+##### Range Filters
 This request supports [range filters](#filters-range-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -196,7 +196,7 @@ This request supports [range filters](#filters-range-filters) over the following
 | affiliation | Range by `affiliation_id`. |
 | modified_by | Range by the `staff_id` of the person to last modify the invoice.|
 
-#### Searching
+##### Searching
 This request supports the [`_search`](#configuring-the-response-searching) paramter to search over the following fields:
 
 | Filter Name |
@@ -204,7 +204,7 @@ This request supports the [`_search`](#configuring-the-response-searching) param
 | subject |
 | invoice_number |
 
-### handling the Response
+#### handling the Response
 The response will be a list of [invoices](#the-invoice-object) on the Deployment, with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters, filters, or searches used.
 
 
@@ -212,7 +212,7 @@ The response will be a list of [invoices](#the-invoice-object) on the Deployment
 
 
 
-## Count Invoices
+### Count Invoices
 > Sample Request:
 
 ```http
@@ -239,7 +239,7 @@ This request will return a count of invoices in a list defined by any available 
 
 
 
-## Get Line Item (Beta)
+### Get Line Item (Beta)
 > Sample Request:
 
 ```http
@@ -258,10 +258,10 @@ curl -X GET \
 
 This request returns a [line item](#the-line-item-beta) specified by its `line_item_id.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [line item object](#the-line-item-beta) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The request will return the single invoice line item with its default fields and any additional fields requested through `_fields`.
 
 
@@ -269,7 +269,7 @@ The request will return the single invoice line item with its default fields and
 
 
 
-## List Line Items (Beta)
+### List Line Items (Beta)
 > Sample request:
 
 ```http
@@ -286,15 +286,15 @@ curl -X GET \
 
 This request returns a list of [invoice line item](#the-line-item-beta).
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all of the standard [pagination parameters](#configuring-the-response-pagination)
 
-#### Additional Fields and Linked objects
+##### Additional Fields and Linked objects
 This request supports requesting additional fields and linked objects from the [line item object](#the-line-item-beta) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-#### Basic Filters
+##### Basic Filters
 This request supports the following [basic filters](#filters-basic-filters):
 
 | Filter |
@@ -304,7 +304,7 @@ This request supports the following [basic filters](#filters-basic-filters):
 | ledger_id |
 | tax_id |
 
-#### Order Filters
+##### Order Filters
 This request supports the following [order filters](#filters-order-filters):
 
 | Filter |
@@ -318,7 +318,7 @@ This request supports the following [order filters](#filters-order-filters):
 | total |
 | ordering |
 
-#### Range Filters
+##### Range Filters
 This request supports [range filters](#filters-range-filters) over the following fields:
 
 | Filter |
@@ -331,14 +331,14 @@ This request supports [range filters](#filters-range-filters) over the following
 | rate |
 | total |
 
-#### Searching
+##### Searching
 This request supports the [`_search`](#configuring-the-response-searching) parameter to search over the following fields:
 
 | Field |
 |:-|
 | description |
 
-### Handling the Response
+#### Handling the Response
 The response will contain a list of invoice line items with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters, filters, or searches used.
 
 
@@ -346,7 +346,7 @@ The response will contain a list of invoice line items with their default fields
 
 
 
-## Count Line Items (Beta)
+### Count Line Items (Beta)
 > Sample request:
 
 ```http

--- a/source/includes/endpoints/_issues.md
+++ b/source/includes/endpoints/_issues.md
@@ -1,10 +1,10 @@
-# Issues
+## Issues
 > Resource URI:  
 `/api/v0/issues`
 
 Issues (also known as "Tickets") are used for when you need to track billable time against a client, but don’t need the complexity of a full Project and its workflow and components. For example, issues may be used to track support cases where you’re diagnosing and fixing a problem and don’t know beforehand the specific steps which will be required to resolve the Issue. See the [support documentation](https://www.accelo.com/resources/help/guides/user/modules/tickets/#WhenTickets) for more information on these objects.
 
-## The Issue Object
+### The Issue Object
 > Example issue object:
 
 ```json
@@ -87,7 +87,7 @@ The issue object contains the following:
 | issue_object_budget | unsigned or object | The [object budget](#object-budgets) associated with the issue. |
 | object_budget | unsigned or object | **Deprecated** please use `issue_object_budget`. |
 
-### The Issue Priority
+#### The Issue Priority
 > Example priority object:
 
 ```json
@@ -108,7 +108,7 @@ Issue priorities help you keep track of what needs to be done. They may be set u
 | color | select | The color of the priority when displayed on the deployment. The colors, in order of increasing urgency a "grey", "blue", "green", "orange", "red". |
 | factor | unsigned | A number representing the urgency of the priority. 5 is "Extreme", 1 is "None". |
 
-### The Issue Status
+#### The Issue Status
 > Example issue status object:
 
 ```json
@@ -133,7 +133,7 @@ Statuses may be used to track the progress of an issue. These statuses may be co
 | start | select | Either "yes" or "no", whether an issue may be created with this status. |
 | ordering | unsigned | A number describing the order of the status on the deployment. |
 
-### The Issue Type
+#### The Issue Type
 > Example issue type object:
 
 ```json
@@ -166,7 +166,7 @@ Issue types let you sort your issues according to the type of work the entail. I
 | default_class_id | unsigned | The unique identifier of the default [issue class](#the-issue-class) for this type of issue. Default is `null`. |
 | has_custom_id | boolean | Either "1" or "0", whether the issue type uses custom ids. |
 
-### The Issue Resolution
+#### The Issue Resolution
 > Example issue resolution:
 
 ```json
@@ -191,7 +191,7 @@ Issue resolutions track how certain issues are resolved and may be set up on the
 | report | string | A fixed description of the resolution. |
 | standing | select | Either "active" or "inactive", the standing of the resolution. |
 
-### The Issue Class
+#### The Issue Class
 > Example issue class:
 
 ```json
@@ -220,7 +220,7 @@ Issue classes help to classify symptoms or characteristics of an issue. They can
 
 
 
-## Get Issue
+### Get Issue
 > Sample Request:  
 
 ```http
@@ -239,10 +239,10 @@ curl -X get \
 
 This request returns a single issue, identified by its `issue_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [issue object](#the-issue-object) using the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-### handling the Response
+#### handling the Response
 The response will be the single requested [issue](#the-issue-object) with its default fields, and any additional fields requested through `_fields`.
 
 
@@ -251,7 +251,7 @@ The response will be the single requested [issue](#the-issue-object) with its de
 
 
 
-## List Issues
+### List Issues
 > Sample Request:  
 
 ```http
@@ -270,13 +270,13 @@ curl -X get \
 
 This request returns a list of [issue objects](#the-issue-object) on the deployment.
 
-### Pagination
+#### Pagination
 This request supports the standard [pagination](#configuring-the-response-pagination) parameters.
 
-### Additional Fields and Linked Objects
+#### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects from the [issues object](#the-issue-object) using the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-#### Basic Filters
+##### Basic Filters
 This request supports [basic filters](#filters-basic-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -302,7 +302,7 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | assignee | Filter by the `staff_id` of the assignee. |
 | contract | Filter by the `contract_id` of any linked contracts. |
 
-#### Date Filters
+##### Date Filters
 This request supports [date filters](#filters-date-filters) over the following fields:
 
 | Filter Name |
@@ -313,7 +313,7 @@ This request supports [date filters](#filters-date-filters) over the following f
 | date_due |
 | date_closed |
 
-#### Order Filters
+##### Order Filters
 This request supports [order filters](#filters-order-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -330,7 +330,7 @@ This request supports [order filters](#filters-order-filters) over the following
 | standing ||
 | status | Order by the `status_id` |
 
-#### Range Filters
+##### Range Filters
 This request supports [range filters](#filters-range-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -355,7 +355,7 @@ This request supports [range filters](#filters-range-filters) over the following
 | rate | Range over the `rate_id` of the rate charged. |
 | contract | Range over the `contract_id` of contracts linked to issues. |
 
-#### Object Filters
+##### Object Filters
 This request supports the following [object filters](#filters-object-filters):
 
 |  Filter Name  | Description |
@@ -363,14 +363,14 @@ This request supports the following [object filters](#filters-object-filters):
 | against | Filter by issues against these objects. |
 | referrer | Filter by issues referred by these objects. |
 
-#### Searching
+##### Searching
 This request supports using the `_search` function to search over the following fields:
 
 | Field |
 |:-|
 | subject |
 
-### handling the Response
+#### handling the Response
 This request will return a list of [issues](#the-issue-object) containing the default fields and any additional fields request by `_fields`, and displayed according to any pagination parameters, filters, or searches used.
 
 
@@ -379,7 +379,7 @@ This request will return a list of [issues](#the-issue-object) containing the de
 
 
 
-## Count Issues
+### Count Issues
 > Sample Request:  
 
 ```http
@@ -408,7 +408,7 @@ This request will return a count of issues in a list defined by any available se
 
 
 
-## List Recent Issues
+### List Recent Issues
 > Sample Request:  
 
 ```http
@@ -427,10 +427,10 @@ curl -X get \
 
 This request returns a list of issues on the deployment sorted by most recently submitted, that is, in descending order of `date_submitted`.
 
-### Configuring the Request
+#### Configuring the Request
 This request accepts the same parameters and filters over the same fields as the [`GET /issues`](#list-issues) request, although it will always be ordered in descending order of `date_submitted`.
 
-### handling the Response
+#### handling the Response
 This request will return a list of contacts displayed according to any parameters used, and with their default fields plus any additional fields requested by `_fields`, and ordered in descending order of `date_submitted`.
 
 
@@ -439,7 +439,7 @@ This request will return a list of contacts displayed according to any parameter
 
 
 
-## List Issue Statuses
+### List Issue Statuses
 > Sample Request:  
 
 ```http
@@ -458,15 +458,15 @@ curl -X get \
 
 This request returns a list of issue [statuses](#statuses) on the deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports the standard [pagination](#configuring-the-response-pagination) requests.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects from the issue [status object](#statuses) through the [`_fields`](#configuring-the-response-fields) parameter.
 
-#### Basic Filters
+##### Basic Filters
 This request supports the following [basic filters](#filters-basic-filters):
 
 | Filter Name |
@@ -476,7 +476,7 @@ This request supports the following [basic filters](#filters-basic-filters):
 | standing |
 | color |
 
-#### Order Filters
+##### Order Filters
 This request supports the following [order filters](#filters-order-filters):
 
 | Filter Name |
@@ -487,14 +487,14 @@ This request supports the following [order filters](#filters-order-filters):
 | color |
 | ordering |
 
-#### Searching
+##### Searching
 This request supports the [`_search`](#configuring-the-response-searching) parameter to search over the following fields:
 
 | Field |
 |:-|
 | title |
 
-### Handling the Response
+#### Handling the Response
 This request will return a list of issue [statuses](#statuses) with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters, filters or searches used.
 
 
@@ -503,7 +503,7 @@ This request will return a list of issue [statuses](#statuses) with their defaul
 
 
 
-## Get Issue Type
+### Get Issue Type
 
 > Sample request:  
 
@@ -523,11 +523,11 @@ curl -X get \
 
 This request returns an [issue type](#issue-type-id) specified by its unique id.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports request additional fields and linked objects from  the issue type using the
 [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 
 The response will contain a single issue type with its default fields and any additional
 fields requested through `_fields`.
@@ -537,7 +537,7 @@ fields requested through `_fields`.
 
 
 
-## List Issue Types
+### List Issue Types
 > Sample Request:  
 
 ```http
@@ -556,15 +556,15 @@ curl -X get \
 
 This request returns a list of [issue types](#the-issue-type) on the deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports the standard [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects from the [issue type object](#the-issue-type) using the [`_fields`](#configuring-the-response-fields) parameter. **Note** this request does not support the `_ALL` argument for this parameter.
 
-### handling the Response
+#### handling the Response
 The response will be a list of [issue types](#the-issue-type) with their default fields and any additional fields requested through `_fields`.
 
 
@@ -573,7 +573,7 @@ The response will be a list of [issue types](#the-issue-type) with their default
 
 
 
-## List Issue Classes
+### List Issue Classes
 > Sample Request:  
 
 
@@ -593,10 +593,10 @@ curl -X get \
 
 This request returns a list of [issue classes](#the-issue-class) on the deployment.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [issue class object](#the-issue-class) using the [`_fields`](#configuring-the-response-fields) parameter. **Note** this request does not support the `_ALL` argument for this parameter.
 
-### handling the Response
+#### handling the Response
 The response will be a list of [issue types](#the-issue-class) with their default fields and any additional fields requested through `_fields`.
 
 
@@ -605,7 +605,7 @@ The response will be a list of [issue types](#the-issue-class) with their defaul
 
 
 
-## List Tasks Against an Issue
+### List Tasks Against an Issue
 > Sample Request:  
 `GET /issues/{issue_id}/tasks`
 
@@ -624,10 +624,10 @@ curl -X get \
 
 This request returns a list of [tasks](#tasks) against an [issue](#the-issue-object) specified by its `issue_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This response may be configuring in the same way as [`GET /tasks`](#list-tasks)
 
-### Handling the Response
+#### Handling the Response
 This response may be handled in the same way as [`GET /tasks`](#list-tasks)
 
 
@@ -636,7 +636,7 @@ This response may be handled in the same way as [`GET /tasks`](#list-tasks)
 
 
 
-## Update an Issue
+### Update an Issue
 > Sample Request:  
 
 ```http
@@ -657,7 +657,7 @@ curl -X get \
 
 This request updates and returns an [issue object](#the-issue-object), identified by its `issue_id`.
 
-### Configuring the Issue
+#### Configuring the Issue
 The following fields from the [issue object](#the-issue-object) may be updated through this request:
 
 || Notes |
@@ -673,10 +673,10 @@ The following fields from the [issue object](#the-issue-object) may be updated t
 | date_due ||
 | assignee | A `staff_id`, must point to a valid [staff](#staff) member. The staff will be assigned and informed of this assigned issue. |
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [issue object](#the-issue-object) using the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-### handling the Response
+#### handling the Response
 The response will be the single updated [issue](#the-issue-object) with its default fields and any additional fields requested through `_fields`.
 
 
@@ -685,7 +685,7 @@ The response will be the single updated [issue](#the-issue-object) with its defa
 
 
 
-## Create an Issue
+### Create an Issue
 > Sample Request:  
 
 ```http
@@ -706,7 +706,7 @@ curl -X get \
 
 This request creates and returns an [issue](#the-issue-object).
 
-### Configuring the Issue
+#### Configuring the Issue
 Values for the following fields from the [issue object](#the-issue-object) may be set through this request:
 
 || Notes |
@@ -724,10 +724,10 @@ Values for the following fields from the [issue object](#the-issue-object) may b
 | class_id | Must point to a valid [issue class](#the-issue-class). You may retrieve a list of classes through [`GET /issues/classes`](#list-issue-classes) |
 | assignee | A `staff_id`, must point to a valid [staff](#staff) member. |
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked resources from the [issue object](#the-issue-object) using the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-### handling the Response
+#### handling the Response
 The response will be the created [issue](#the-issue-object) with its default fields and any additional fields requested through `_fields`.
 
 
@@ -736,7 +736,7 @@ The response will be the created [issue](#the-issue-object) with its default fie
 
 
 
-## Delete an Issue
+### Delete an Issue
 > Sample Request:  
 
 ```http
@@ -761,7 +761,7 @@ This request removes an issue from the deployment, specified by its `issue_id`. 
 
 
 
-## List Profile Fields
+### List Profile Fields
 > See the [profiles section](#retrieve-a-list-of-profile-fields) for a sample request  
 
 `GET /issues/profiles/fields`
@@ -774,7 +774,7 @@ This request returns a list of [profile fields](#the-profile-field-object) avail
 
 
 
-## List Profile Field Values
+### List Profile Field Values
 > See the [profiles section](#retrieve-a-list-of-profile-values) for a sample request
 
 `GET /issues/{issue_id}/profiles/values`
@@ -787,7 +787,7 @@ This request returns a list of [profile values](#the-profile-value-object) of an
 
 
 
-## Update a Profile Value
+### Update a Profile Value
 > See the [profiles section](#update-a-profile-value-link) for a sample request  
 
 `PUT /issues/issue_id/profiles/values/{profile_value_id}`
@@ -800,7 +800,7 @@ This request updates and returns a [profile value](#the-profile-value-object), s
 
 
 
-## Set a Profile Value
+### Set a Profile Value
 > See the [profiles section](#create-a-profile-value-link) for a sample request
 
 `POST /issues/{issue_id}/profiles/fields/{profile_field_id}`
@@ -813,7 +813,7 @@ This request sets and returns a [profile value](#the-profile-value-object) for a
 
 
 
-## List Extension Fields
+### List Extension Fields
 > See the [extension section](#retrieve-a-list-of-extension-fields) for an example  
 
 `GET /issues/extensions/fields`
@@ -826,7 +826,7 @@ This request returns a list of [extension fields](#the-extension-field-object) a
 
 
 
-## List Extension Field Values
+### List Extension Field Values
 > See the [extension section](#retrieve-a-list-of-extension-field-values) for an example    
 
 `GET /issues/{issue_id}/extensions/values`
@@ -839,7 +839,7 @@ This request returns a list of [extension values](#the-extension-value-object) f
 
 
 
-## Update an Extension Field Value
+### Update an Extension Field Value
 > See the [extension section](#update-an-extension-value) for an example      
 
 `PUT /issues/{issue_id}/extensions/values/{extension_value_id}`
@@ -852,7 +852,7 @@ This request updates the value of an [extension field value](#the-extension-valu
 
 
 
-## Set an Extension Field Value
+### Set an Extension Field Value
 > Sample Request:  
 
 `POST /issues/{issue_id}/extensions/fields/{extension_field_id}`
@@ -866,7 +866,7 @@ This request sets and returns the value of an extension field, specified by its 
 
 
 
-## List Available Progressions
+### List Available Progressions
 > See the [progressions section](#retrieve-a-list-of-available-progressions) for a sample request  
 
 `GET /issues/{issue_id}/progressions`
@@ -879,7 +879,7 @@ This request returns a list of available [progressions](#the-progression-object)
 
 
 
-## Auto Run a Progression
+### Auto Run a Progression
 > See the [progressions section](#run-a-status-update-using-a-given-progression) for a sample request  
 
 `[POST|PUT] /issues/{issue_id}/progressions/{progression_id}/auto`
@@ -892,7 +892,7 @@ This request uses the given progression, specified by its `progression_id` to pr
 
 
 
-## List Resource Collections
+### List Resource Collections
 > See the [resources (attachments) section](#retrieve-an-array-of-collections-for-an-object) for an example  
 
 `GET /issues/{issue_id}/collections`
@@ -905,7 +905,7 @@ This request returns a list of [resource collections](#resources-attachments) ag
 
 
 
-## Upload a Resource (Attachment)
+### Upload a Resource (Attachment)
 > See the [resources (attachments) section](#upload-a-resource-to-a-collection-of-an-object) for an example   
 
 `POST /issues/{issue_id}/collections/{collection_id}/resources`

--- a/source/includes/endpoints/_jobs.md
+++ b/source/includes/endpoints/_jobs.md
@@ -1,10 +1,10 @@
-# Jobs (Projects)
+## Jobs (Projects)
 > Resource URI:  
 `api/v0/jobs`
 
  Jobs (or Projects) help you to plan, delegate and track client and internal projects. Projects can be as simple or complex as you like, see the [support documentation](https://www.accelo.com/resources/help/guides/user/modules/projects/) for more information.
 
-## The Jobs Object
+### The Jobs Object
 > Example job object:
 
 ```json
@@ -67,7 +67,7 @@ The jobs object contains the following:
 | job_object_budget | unsigned or object | The [object budget](#object-budgets) associated with the job. |
 | job_contract | unsigned or object | The [contract](#contracts) associated with the job, if any. |
 
-### The Job Type
+#### The Job Type
 > Example job type:
 
 ```json
@@ -100,7 +100,7 @@ request it via `job_type()`, this object will have an additional field:
 
 
 
-## Get Job
+### Get Job
 > Sample Request:  
 
 ```http
@@ -119,10 +119,10 @@ curl -X get \
 
 This request returns a single [job](#the-jobs-object), specified by its `job_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked resources from the [job object](#the-jobs-object) using the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-### handling the Response
+#### handling the Response
 The response will be the single job with its default fields and any additional fields requested through `_fields`.
 
 
@@ -131,7 +131,7 @@ The response will be the single job with its default fields and any additional f
 
 
 
-## List Jobs
+### List Jobs
 > Sample Request:  
 
 ```http
@@ -150,15 +150,15 @@ curl -X get \
 
 This request returns a list of [jobs](#the-jobs-object) on the deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Object
+##### Additional Fields and Linked Object
 This request supports requesting additional fields and linked objects from the [jobs object](#the-jobs-object) using the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-#### Basic Filters
+##### Basic Filters
 This request supports [basic filters](#filters-basic-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -176,7 +176,7 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | rate | Filter by the `rate_id`. |
 | affiliation | Filter by the `affiliation_id`. |
 
-#### Date Filters
+##### Date Filters
 This request supports [date filters](#filters-date-filters) over the following fields:
 
 | Filter Name |
@@ -188,7 +188,7 @@ This request supports [date filters](#filters-date-filters) over the following f
 | date_due |
 | date_completed |
 
-#### Order Filters
+##### Order Filters
 This request supports [order filters](#filters-order-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -205,7 +205,7 @@ This request supports [order filters](#filters-order-filters) over the following
 | standing |
 | status | Order by the `status_id`. |
 
-#### Range Filters
+##### Range Filters
 This request supports [range filters](#filters-range-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -223,21 +223,21 @@ This request supports [range filters](#filters-range-filters) over the following
 | contract | Range by the `contract_id` of any contract associated with the job. |
 | plan_modified_by | Range by the `staff_id` of the last staff member to modify the job plan. |
 
-#### Object Filters
+##### Object Filters
 This request supports the following [object filters](#filters-object-filters):
 
 | Filter | Description |
 |:-|:-|
 | against | Filter by jobs against these objects. |
 
-#### Searching
+##### Searching
 This request supports the [`_search`](#configuring-the-response-searching) filter to search over the following fields:
 
 | Field |
 |:-|
 | title |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [job objects](#the-jobs-object) containing the default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters, filters or searches used.
 
 
@@ -246,7 +246,7 @@ The response will be a list of [job objects](#the-jobs-object) containing the de
 
 
 
-## Count Jobs
+### Count Jobs
 > Sample Request:  
 
 ```http
@@ -276,7 +276,7 @@ This request will return a count of jobs in a list defined by any available sear
 
 
 
-## List Recent Jobs
+### List Recent Jobs
 > Sample Request:  
 
 ```http
@@ -295,10 +295,10 @@ curl -X get \
 
 This request returns a list of [job](#the-jobs-object) on the deployment, sorted by the most recently created, that is in descending order of `date_created`.
 
-### Configuring the Response
+#### Configuring the Response
 The response to this response may be configured as per [`GET /jobs`](#list-jobs), although any [order filters](#filters-order-filters) used will have no impact on the response.
 
-### handling the Response
+#### handling the Response
 This request will return a list of [job objects](#the-jobs-object) on the deployment with their default fields and any additional fields requested through `_fields`, displayed in descending order of `date_created` and according to any pagination parameters, filters, or searches used.
 
 
@@ -307,7 +307,7 @@ This request will return a list of [job objects](#the-jobs-object) on the deploy
 
 
 
-## List Latest Modified Jobs
+### List Latest Modified Jobs
 > Sample Request:  
 
 ```http
@@ -326,10 +326,10 @@ curl -X get \
 
 This request returns a list of [jobs](#the-jobs-object) on the deployment, sorted by the most recently modified, that is, in descending order of `date_modified`.
 
-### Configuring the Response
+#### Configuring the Response
 The response to this response may be configured as per [`GET /jobs`](#list-jobs), although any [order filters](#filters-order-filters) used will have no impact on the response.
 
-### handling the Response
+#### handling the Response
 This request will return a list of [job objects](#the-jobs-object) on the deployment with their default fields and any additional fields requested through `_fields`, displayed in descending order of `date_modified` and according to any pagination parameters, filters, or searches used.
 
 
@@ -337,7 +337,7 @@ This request will return a list of [job objects](#the-jobs-object) on the deploy
 
 
 
-## Get Job Type
+### Get Job Type
 > Sample request:  
 
 ```http
@@ -359,11 +359,11 @@ curl -X get \
 
 This request returns a [job type](#the-job-type) specified by its unique id.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the
 job type object using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will contain a single job type with its default fields and any additional
 fields requested through `_fields`.
 
@@ -371,7 +371,7 @@ fields requested through `_fields`.
 
 
 
-## List Job Types
+### List Job Types
 
 > Sample request:  
 
@@ -396,16 +396,16 @@ curl -X get \
 
 This request returns a list of [job types](#the-job-type).
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects from the
 job type using the [`_fields`](#configuring-the-response-fields) parameter.
 
-#### Basic Filters
+##### Basic Filters
 This request supports the following [basic filters](#filters-basic-filters):
 
 | Filter |
@@ -413,7 +413,7 @@ This request supports the following [basic filters](#filters-basic-filters):
 | id |
 | standing |
 
-#### Order Filters
+##### Order Filters
 This request supports [order filters](#filters-order-filters) over the following fields:
 
 | Field |
@@ -422,14 +422,14 @@ This request supports [order filters](#filters-order-filters) over the following
 | title |
 | standing |
 
-#### Range Filters
+##### Range Filters
 This request supports [range filters](#filters-range-filters) over the following fields:
 
 | Field |
 |:-|
 | id |
 
-#### Searching
+##### Searching
 This request supports the [`_search`](#configuring-the-response-searching) parameter
 to search over the following fields:
 
@@ -437,7 +437,7 @@ to search over the following fields:
 |:-|
 | title |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [job types](#the-job-type) with their default fields
 and any additional fields requested through `_fields`, and displayed according to
 any pagination parameters, filters, or searches used.
@@ -447,7 +447,7 @@ any pagination parameters, filters, or searches used.
 
 
 
-## List Job Milestones
+### List Job Milestones
 > Sample Request:  
 
 ```http
@@ -471,7 +471,7 @@ This request returns a list of [milestones](#milestones) of a job, specified by 
 
 
 
-## Update a Job
+### Update a Job
 > Sample Request:
 
 ```http
@@ -492,7 +492,7 @@ curl -X get \
 
 This request updates and returns a [job](#the-jobs-object), specified by its `job_id`.
 
-### Configuring the Job
+#### Configuring the Job
 The following fields from the [job object](#the-jobs-object) may be updated with this request:
 
 | Filter Name | Notes |
@@ -510,10 +510,10 @@ The following fields from the [job object](#the-jobs-object) may be updated with
 | date_due ||
 | date_created ||
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked resources from the [jobs object](#the-jobs-object) through the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-### handling the Response
+#### handling the Response
 The response will be the single, updated [job](#the-jobs-object) with its default fields and any additional fields requested through `_fields`.
 
 
@@ -522,7 +522,7 @@ The response will be the single, updated [job](#the-jobs-object) with its defaul
 
 
 
-## Create a Job
+### Create a Job
 > Sample Request:  
 
 ```http
@@ -543,7 +543,7 @@ curl -X get \
 
 This request creates and returns a new [job](#the-jobs-object).
 
-### Configuring the Job
+#### Configuring the Job
 The following fields may be set through this request:
 
 | Filter Name | Notes |
@@ -562,10 +562,10 @@ The following fields may be set through this request:
 | date_started ||
 | date_created | If this is not sent it will default to the current time. |
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked resources from the [jobs object](#the-jobs-object) through the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-### handling the Response
+#### handling the Response
 The response will be the single, created [job](#the-job-object) with its default fields and any additional fields requested through `_fields`.
 
 
@@ -574,7 +574,7 @@ The response will be the single, created [job](#the-job-object) with its default
 
 
 
-## Delete a Job
+### Delete a Job
 > Sample Request:  
 
 ```http
@@ -599,7 +599,7 @@ This request deletes a job from the deployment, specified by its `job_id`. This 
 
 
 
-## List Extension Fields
+### List Extension Fields
 > See the [extension section](#retrieve-a-list-of-extension-fields) for an example
 
 `GET /jobs/extensions/fields`
@@ -612,7 +612,7 @@ This request returns a list of [extension fields](#the-extension-field-object) a
 
 
 
-## List Extension Field Values
+### List Extension Field Values
 > See the [extension section](#retrieve-a-list-of-extension-field-values) for an example    
 
 `GET /jobs/{job_id}/extensions/values`
@@ -625,7 +625,7 @@ This request returns a list of [extension values](#the-extension-value-object) f
 
 
 
-## Update an Extension Field Value
+### Update an Extension Field Value
 > See the [extension section](#update-an-extension-value) for an example     
 
 `PUT /jobs/{job_id}/extensions/values/{extension_value_id}`
@@ -638,7 +638,7 @@ This request updates the value of an [extension field value](#the-extension-valu
 
 
 
-## Set an Extension Field Value
+### Set an Extension Field Value
 > Sample Request:  
 
 `POST /jobs/{job_id}/extensions/fields/{extension_field_id}`
@@ -652,7 +652,7 @@ This request sets and returns the value of an extension field, specified by its 
 
 
 
-## List Available Progressions
+### List Available Progressions
 > See the [progressions section](#retrieve-a-list-of-available-progressions) for a sample request
 
 `GET /jobs/{jobs_id}/progressions`
@@ -665,7 +665,7 @@ This request returns a list of available [progressions](#the-progression-object)
 
 
 
-## Auto Run Progression
+### Auto Run Progression
 > See the [progressions section](#run-a-status-update-using-a-given-progression) for a sample request
 
 `[POST|PUT] /jobs/{jobs_id}/progressions/{progression_id}/auto`
@@ -678,7 +678,7 @@ This request uses the given progression, specified by its `progression_id` to pr
 
 
 
-## List Resource Collections
+### List Resource Collections
 > See the [resources (attachments) section](#retrieve-an-array-of-collections-for-an-object) for an example
 
 `GET /jobs/{job_id}/collections`
@@ -691,7 +691,7 @@ This request returns a list of [resource collections](#resources-attachments) ag
 
 
 
-## Upload a resource (Attachment)
+### Upload a resource (Attachment)
 > See the [resources (attachments) section](#upload-a-resource-to-a-collection-of-an-object) for an example   
 
 `POST jobs/{job_id}/collections/{collection_id}/resources`

--- a/source/includes/endpoints/_ledgers.md
+++ b/source/includes/endpoints/_ledgers.md
@@ -1,7 +1,7 @@
-# Ledgers
+## Ledgers
 Accelo supports account ledgers, it also allows account ledger integration with certain online accounting systems (e.g. Xero). These account ledgers are described by the API through the `ledger` object. For information on viewing, adding and syncing account ledgers from your deployment, please see the [support documentation](https://www.accelo.com/resources/help/guides/settings-and-configuration-guide/modules/billing-and-invoices/ledgers/).
 
-## The Ledger Object (Beta)
+### The Ledger Object (Beta)
 > Example ledger
 
 ```json
@@ -31,7 +31,7 @@ The ledger object contains the following:
 
 
 
-## Get Ledger (Beta)
+### Get Ledger (Beta)
 
 ```http
 GET /api/v0/ledgers/{ledger_id} HTTP/1.1
@@ -49,17 +49,17 @@ curl -X GET \
 
 This request returns a [ledger](#the-ledger-object-beta) identified by its unique `ledger_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [ledger object](#the-ledger-object-beta) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response wil be the single ledger with its default fields and any additional fields requested through `_fields`.
 
 
 
 
 
-## List Ledgers (Beta)
+### List Ledgers (Beta)
 
 ```http
 GET /api/v0/ledgers HTTP/1.1
@@ -77,15 +77,15 @@ curl -X GET \
 
 This request returns a list of [ledgers](#the-ledger-object-beta).
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all the standard [pagination parameters](#configuring-the-response-pagination).
 
-#### Additional fields and Linked Objects
+##### Additional fields and Linked Objects
 This request supports requesting additional fields and linked objects from the [ledger object](#the-ledger-object-beta) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-#### Basic Filters
+##### Basic Filters
 This request supports the following [basic filters](#filters-basic-filters):
 
 | Filter |
@@ -95,7 +95,7 @@ This request supports the following [basic filters](#filters-basic-filters):
 | parent_id |
 | standing |
 
-#### Order Filters
+##### Order Filters
 This request supports the following [order filters](#filters-order-filters):
 
 | Filter |
@@ -106,7 +106,7 @@ This request supports the following [order filters](#filters-order-filters):
 | standing |
 | title |
 
-#### Range Filters
+##### Range Filters
 This request supports the following [range filters](#filters-range-filters):
 
 | Filter |
@@ -114,7 +114,7 @@ This request supports the following [range filters](#filters-range-filters):
 | id |
 | parent_id |
 
-#### Searching
+##### Searching
 This request supports the [`_search`](#configuring-the-response-searching) parameter to search over the following fields:
 
 | Field |
@@ -122,7 +122,7 @@ This request supports the [`_search`](#configuring-the-response-searching) param
 | title |
 | code |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [ledgers](#the-ledger-object-beta) with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters, filters, or searches used.
 
 
@@ -130,7 +130,7 @@ The response will be a list of [ledgers](#the-ledger-object-beta) with their def
 
 
 
-## Count Ledgers (Beta)
+### Count Ledgers (Beta)
 
 ```http
 GET /api/v0/ledgers/count HTTP/1.1

--- a/source/includes/endpoints/_milestones.md
+++ b/source/includes/endpoints/_milestones.md
@@ -1,4 +1,4 @@
-# Milestones
+## Milestones
 > Resource URI:  
 `/api/vo/milestones`
 
@@ -6,7 +6,7 @@ Milestones are the steps on the road to a [Job's](#jobs-projects) (Project's) co
 
 Deleting, creating, and updating milestones is only available through the deployment on the project planning screen, see the [support documentation](https://www.accelo.com/resources/help/guides/user/modules/projects/creating-a-project-plan/) for more information.
 
-## The Milestone Object
+### The Milestone Object
 > Example milestone object:
 
 ```json
@@ -63,7 +63,7 @@ The milestone object contains the following:
 
 
 
-## Get Milestone
+### Get Milestone
 > Sample Request:  
 
 ```http
@@ -82,10 +82,10 @@ curl -X get \
 
 This request returns a single [milestone](#the-milestone-object), identified by its `milestone_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked resource from the [milestone object](#the-milestone-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### handling the Response
+#### handling the Response
 The response will be the single [milestone](#the-milestone-object) with its default fields and any additional fields requested through `_fields`.
 
 
@@ -94,7 +94,7 @@ The response will be the single [milestone](#the-milestone-object) with its defa
 
 
 
-## List Milestones
+### List Milestones
 > Sample Request:  
 
 ```http
@@ -113,15 +113,15 @@ curl -X get \
 
 This request returns a list of [milestones](#the-milestone-object) on the deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports request additional fields and linked objects from the [milestone object](#the-milestone-object) using the [`_fields`](#configuring-the-response-fields).
 
-#### Basic Filters
+##### Basic Filters
 This request supports [basic filters](#filters-basic-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -136,7 +136,7 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | object_budget | Filter by the `object_budget_id`. |
 | status | Filter by the `status_id`. |
 
-#### Date Filters
+##### Date Filters
 This request supports [date filters](#filters-date-filters) over the following fields:
 
 | Filter Name |
@@ -148,7 +148,7 @@ This request supports [date filters](#filters-date-filters) over the following f
 | date_due |
 | date_completed |
 
-#### Range Filters
+##### Range Filters
 This request supports [range filters](#filters-range-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -161,14 +161,14 @@ This request supports [range filters](#filters-range-filters) over the following
 | rate | Range by the `rate_id`. |
 | rate_charged ||
 
-#### Searching
+##### Searching
 This request supports the [`_search`](#configuring-the-response-searching) parameter to search over the following fields:
 
 | Filter Name |
 |:-|
 | title |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [milestones](#the-milestone-object) containing their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters, filters, or searches used.
 
 
@@ -177,7 +177,7 @@ The response will be a list of [milestones](#the-milestone-object) containing th
 
 
 
-## Count Milestones
+### Count Milestones
 > Sample Request:  
 
 ```http
@@ -206,7 +206,7 @@ This request will return a count of milestones in a list defined by any availabl
 
 
 
-## List Profile Fields
+### List Profile Fields
 > See the [profiles section](#retrieve-a-list-of-profile-fields)) for a sample request
 
 `GET /milestones/profiles/fields`
@@ -219,7 +219,7 @@ This request returns a list of [profile fields](#the-profile-field-object) avail
 
 
 
-## List Profile Field Values
+### List Profile Field Values
 > See the [profiles section](#retrieve-a-list-of-profile-values) for a sample request  
 
 `GET /milestones/{milestone_id}/profiles/values`
@@ -232,7 +232,7 @@ This request returns a list of [profile values](#the-profile-value-object) of a 
 
 
 
-## Update a Profile Field Value
+### Update a Profile Field Value
 > See the [profiles section](#update-a-profile-value-link) for a sample request   
 
 `PUT /milestones/{milestone_id}/profiles/values/{profile_value_id}`
@@ -245,7 +245,7 @@ This request updates and returns a [profile value](#the-profile-value-object), s
 
 
 
-## Set a Profile Field Value
+### Set a Profile Field Value
 > See the [profiles section](#create-a-profile-value-link) for a sample request
 
 `POST /milestones/{milestone_id}/profiles/fields/{profile_field_id}`
@@ -258,7 +258,7 @@ This request sets and returns a [profile value](#the-profile-value-object) for a
 
 
 
-## List Available Progressions
+### List Available Progressions
 > See the [progressions section](#retrieve-a-list-of-available-progressions) for a sample request
 
 `GET /milestones/{milestone_id}/progressions`
@@ -271,7 +271,7 @@ This request returns a list of available [progressions](#the-progression-object)
 
 
 
-## Auto Run a Progression
+### Auto Run a Progression
 > See the [progressions section](#run-a-status-update-using-a-given-progression) for a sample request
 
 `PUT|POST /milestones/{milestone_id}/progressions/{progression_id}/auto`

--- a/source/includes/endpoints/_object_budgets.md
+++ b/source/includes/endpoints/_object_budgets.md
@@ -1,10 +1,10 @@
-# Object Budgets
+## Object Budgets
 > Resource URI:  
 `api/v0/object_budgets`
 
 Object budgets are budgets against a specific object, for example a budget against an [issue](#issues) or a [milestone](#milestones). They are able to track the time and money spent by staff and on services, as well as expenses and the cost of materials.
 
-## The Object Budget
+### The Object Budget
 > Exmaple object budget:
 
 ```json
@@ -76,7 +76,7 @@ The object budget resource contains the following:
 
 
 
-## Get Object budget
+### Get Object budget
 > Sample Request:  
 
 ```http
@@ -95,10 +95,10 @@ curl -X get \
 
 This request returns an [object budget](#the-object-budget) identified by its `object_budget_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [object budget](#the-object-budget) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be the single [object budget](#the-object-budget) with its default fields and any additional fields requested through `_fields`.
 
 
@@ -107,7 +107,7 @@ The response will be the single [object budget](#the-object-budget) with its def
 
 
 
-## List Object Budgets
+### List Object Budgets
 > Sample Request:  
 
 ```http
@@ -126,15 +126,15 @@ curl -X get \
 
 This request returns a list of [object budgets](#the-object-budget) on the deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects from the [object budget](#the-object-budget) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-#### Basic Filters
+##### Basic Filters
 This request supports the following [basic filters](#filters-basic-filters):
 
 | Filter Name |
@@ -143,21 +143,21 @@ This request supports the following [basic filters](#filters-basic-filters):
 | against_id |
 | against_type |
 
-#### Order Filters
+##### Order Filters
 This request supports the following [order filters](#filters-order-filters):
 
 | Filter Name |
 |:-|
 | id |
 
-#### Object Filters
+##### Object Filters
 This request supports the following [object filters](#filters-object-filters):
 
 | Filter Name |
 |:-|
 | against | Filter by object budgets against these objects. |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [object budgets](#the-object-budget) with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination requests used.
 
 
@@ -166,7 +166,7 @@ The response will be a list of [object budgets](#the-object-budget) with their d
 
 
 
-## Count Object Budgets
+### Count Object Budgets
 > Sample Request:  
 
 ```http

--- a/source/includes/endpoints/_payments.md
+++ b/source/includes/endpoints/_payments.md
@@ -1,9 +1,9 @@
-# Payments
+## Payments
 > Resource URI  
 `/api/v0/payments`
 
 Payments made, for example against an invoice, are stored under the `payments` object through the API. Attached to these payments are methods, receipts, and the currency used. 
-## The Payment Object (Beta)
+### The Payment Object (Beta)
 > Sample payment object:
 
 ```json
@@ -42,7 +42,7 @@ The payment object contains the following:
 | payment_method | unsigned or object | The [method](#the-payment-method-object-beta) of the payment. |
 | payment_receipt | unsigned or objects| The [receipt](#the-payment-receipt-object-beta) for the payment. |
 
-### The Payment Receipt Object (Beta)
+#### The Payment Receipt Object (Beta)
 > Sample receipt object:
 
 ```json
@@ -66,7 +66,7 @@ Where a payment object stores the information on a payment made against a single
 | owner_type | select | Either "staff" or "contact", the type of owner of the receipt. |
 
 
-### The Payment Method Object (Beta)
+#### The Payment Method Object (Beta)
 > Sample payment method object:
 
 ```json
@@ -85,7 +85,7 @@ The payment method describes the different methods payment may be given, for exa
 | **title** | string | A name for the method. |
 | standing | select | Either "active" or "inactive", the standing of the method. |
 
-### The Currency Object (Beta)
+#### The Currency Object (Beta)
 > Sample currency object:
 
 ```json
@@ -113,7 +113,7 @@ The different currencies that may be handled by your deployment are stored in th
 
 
 
-## Get Payment (Beta)
+### Get Payment (Beta)
 > Sample request, list payments against a specific invoice:
 
 ```http
@@ -134,10 +134,10 @@ curl -X GET \
 
 This request returns a [payment](#the-payment-object-beta) identified by its unique `payment_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked object from the [payment object](#the-payment-object-beta) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be the single payment object with its default fields and any additional fields requested through `_fields`.
 
 
@@ -145,7 +145,7 @@ The response will be the single payment object with its default fields and any a
 
 
 
-## List Payments (Beta)
+### List Payments (Beta)
 > Sample request:
 
 ```http
@@ -164,15 +164,15 @@ curl -X GET \
 
 This request returns a list of [payments](#the-payment-object-beta) on the deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all the standard [pagination parameters](#configuring-the-response-pagination).
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked object from the [payment object](#the-payment-object-beta) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-#### Basic Filters
+##### Basic Filters
 This request supports the following [basic filters](#filters-basic-filters):
 
 | Filter |
@@ -185,14 +185,14 @@ This request supports the following [basic filters](#filters-basic-filters):
 | against_id |
 | against_type |
 
-#### Date Filters
+##### Date Filters
 This request supports [date filters](#filters-date-filters) over the following fields:
 
 | Field |
 |:-|
 | date_created |
 
-#### Order Filters
+##### Order Filters
 This request supports the following [order filters](#filters-order-filters):
 
 | Filter |
@@ -207,7 +207,7 @@ This request supports the following [order filters](#filters-order-filters):
 | direction |
 | against_id |
 
-#### Range Filters
+##### Range Filters
 This request supports the following [range filters](#filters-range-filters):
 
 | Filter |
@@ -220,14 +220,14 @@ This request supports the following [range filters](#filters-range-filters):
 | amount |
 | against_id |
 
-#### Object Filters
+##### Object Filters
 This request supports the following [object filters](#filters-object-filters):
 
 | Filter | Description |
 |:-|:-|
 | against | Filter by the object the payment is against. |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [payments](#the-payment-object-beta) with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters or filters used.
 
 
@@ -235,7 +235,7 @@ The response will be a list of [payments](#the-payment-object-beta) with their d
 
 
 
-## Count Payments (Beta)
+### Count Payments (Beta)
 > Sample request:
 
 ```http

--- a/source/includes/endpoints/_profiles.md
+++ b/source/includes/endpoints/_profiles.md
@@ -1,4 +1,4 @@
-# Profiles
+## Profiles
 Profile fields are objects used for tracking extra information from your Accelo deployment. See the [support documentation](https://www.accelo.com/resources/help/guides/settings-and-configuration-guide/triggers-and-business-processes/custom-fields/profile-fields/) for further information about profile fields. Currently, custom profile fields are supported on the following objects:  
 1. [Companies](#companies)  
 2. [Contacts](#contacts)  
@@ -8,7 +8,7 @@ Profile fields are objects used for tracking extra information from your Accelo 
 6. [Milestones](#milestones)  
 7. [Staff](#staff)
 
-## The Profile Field Object
+### The Profile Field Object
 > Example profile field:
 
 ```json
@@ -45,7 +45,7 @@ These are objects describing the custom fields on the deployment, they contain t
 | description | string | A description of the profile field. |
 
 
-## The Profile Value Object
+### The Profile Value Object
 > Example profile value object:
 
 ```json
@@ -82,7 +82,7 @@ These are objects describing a value of a given [profile field](#the-profile-fie
 
 
 <a name="retrieve-a-list-of-profile-fields"></a>
-## List Profile Fields
+### List Profile Fields
 > Sample Request:  
 
 ```http
@@ -101,10 +101,10 @@ curl -X get \
 
 This request returns a list of [profile fields](#the-profile-field-object) available for the given object.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [profile field object](#the-profile-field-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### handling the Response
+#### handling the Response
 This response will be a list of [profile fields](#the-profile-field-object) with their default fields, and any additional fields requested through `_fields`.
 
 
@@ -113,7 +113,7 @@ This response will be a list of [profile fields](#the-profile-field-object) with
 
 
 <a name="retrieve-a-list-of-profile-values"></a>
-## List Profile Field Values
+### List Profile Field Values
 > Sample Request:  
 
 ```http
@@ -132,10 +132,10 @@ curl -X get \
 
 This request returns a list of [profile values](#the-profile-value-object) for the given `object` of identified by `object_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [profile value object](#the-profile-value-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### handling the Response
+#### handling the Response
 This response will be a list of [profile values](#the-profile-value-object) with their default fields, and any additional fields requested through `_fields`.
 
 
@@ -144,7 +144,7 @@ This response will be a list of [profile values](#the-profile-value-object) with
 
 
 <a name="update-a-profile-value-link"></a>
-## Update a Profile Value
+### Update a Profile Value
 > Example, a business has changed its opening hours:
 
 ```shell
@@ -159,7 +159,7 @@ curl -X put \
 
 This request updates and returns a [profile value](#the-profile-value-object), specified by its `profile_value_id`, of a particular object, specified by its `object_id`, of a particular type, specified by `object`.
 
-### Configuring the Profile Value
+#### Configuring the Profile Value
 This request updates the `value` of a profile value, since this object is dynamic the field we send will depend on the type of `value`:
 
 | Field Name | Type | Description |
@@ -170,10 +170,10 @@ This request updates the `value` of a profile value, since this object is dynami
 | value_type | string | If `field_type` is "lookup", update the `value_type` with this string. |
 | value | string | If `field_type` is none of the above, update the `value` with this string. |
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [profile value object](#the-profile-field-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be the single, updated [profile value](#the-profile-value-object) with its default fields, and any additional fields requested through `_fields`.
 
 
@@ -182,7 +182,7 @@ The response will be the single, updated [profile value](#the-profile-value-obje
 
 
 <a name="create-a-profile-value-link"></a>
-## Create a Profile Value
+### Create a Profile Value
 > Example, a company has give us their business hours:
 
 ```shell
@@ -197,11 +197,11 @@ curl -X post \
 
 This request sets and returns a [profile value](#the-profile-value-object) for a profile field, specified by its `profile_field_id`. The object whose profile field is to be update is identified by `object_id` and `object`.
 
-### Configuring the Profile Value
+#### Configuring the Profile Value
 This request accepts the same fields as the [previous request](#configuring-the-profile-value), that is, it takes only the relevant value field(s). The relevant value field is required for this request.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [profile value object](#the-profile-field-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be the newly created [profile value](#the-profile-value-object) with its default fields, and any additional fields requested through `_fields`.

--- a/source/includes/endpoints/_progressions.md
+++ b/source/includes/endpoints/_progressions.md
@@ -1,4 +1,4 @@
-# Progressions
+## Progressions
 Progressions allow you and your team to intelligently move records between statuses. The Public API currently supports automatic progressions, which skip over details requiring user interaction. These automatic progressions are currently supported over the following resources:  
 1. [tasks](#tasks)  
 2. [companies](#companies)  
@@ -16,7 +16,7 @@ Progressions allow you and your team to intelligently move records between statu
 See the [support documentation](https://www.accelo.com/resources/help/guides/settings-and-configuration-guide/triggers-and-business-processes/business-processes/progressions/) for information on progressions, including how to define new progressions on your deployment.
 
 
-## The Progression Object
+### The Progression Object
 > Example progression object:
 
 ```json
@@ -37,7 +37,7 @@ The progressions object contains the following fields and linked objects:
 | **status** | object | The [status](#status-objects) the progression will move to. Note, the status object here does not contain the `start` field. |
 
 
-### Using Progressions
+#### Using Progressions
 Progressions may be used to perform an automatic status update, this is a three step process:  
 1. Determine which status progressions are available for the given object, this is achieved by a `GET` request which [retrieves a list of available progressions](#retrieve-a-list-of-available-progressions).  
 2. From this list identify the appropriate progressions for your action, keep track of the `progression_id`.  
@@ -49,7 +49,7 @@ Progressions may be used to perform an automatic status update, this is a three 
 
 
 
-## List Available Progressions
+### List Available Progressions
 <a name="retrieve-a-list-of-available-progressions"></a>
 > Example request:
 
@@ -64,7 +64,7 @@ curl -X get \
 
 This request returns a list of [progressions](#the-progression-object) available for a given resource, which may be one of the types [above](#progressions), specified by its unique resource id.
 
-### Handling the Response
+#### Handling the Response
 This request will return a list of [progressions](#the-progression-object) available for the object given, displayed in ascending order of their `progression_id`.
 
 
@@ -73,7 +73,7 @@ This request will return a list of [progressions](#the-progression-object) avail
 
 
 
-## Auto Run a Progression
+### Auto Run a Progression
 <a name="run-a-status-update-using-a-given-progression"></a>
 > Example request, we wish to move our job to "complete" from the above request we found that the progression with id "8" will do this:
 
@@ -88,5 +88,5 @@ curl -X post \
 
 This request uses the given progression, specified by its `progression_id` to progress the status of the object, specified by its unique id. The object may be any one of those listed [above](#progressions).
 
-### Handling the Response
+#### Handling the Response
 The response will contain the single updated object. Please see the appropriate resource endpoint for handling and configuring the response.

--- a/source/includes/endpoints/_prospects.md
+++ b/source/includes/endpoints/_prospects.md
@@ -1,10 +1,10 @@
-# Prospects (Sales)
+## Prospects (Sales)
 > Resource URI:  
 `api/v0/prospects`
 
 Prospects (also known as Sales) are a way to keep track of your sales and deals. See the [support documentation](https://www.accelo.com/resources/help/guides/user/modules/sales/) for more information on the full potential of these, and also information on setting up and configuring them via the deployment.
 
-## The Prospect Object
+### The Prospect Object
 > Example prospects object
 
 ```json
@@ -59,7 +59,7 @@ The prospect object contains the following:
 | prospect_probability | unsigned or object | The [prospect probability](#the-prospect-probability) of the prospect. |
 | affiliation | unsigned or object | The [affiliation](#affiliations) associated with the prospect. |
 
-### The Prospect Type
+#### The Prospect Type
 > Example prospect type object:
 
 ```json
@@ -82,7 +82,7 @@ You may group prospect using prospect types to reflect the different actions tak
 | standing | select | The standing of the prospect type, may be either "active" or "inactive". |
 | ordering | integer | An integer representing the prospect type's ordering as displayed on the deployment. |
 
-### The Prospect Probability
+#### The Prospect Probability
 Prospect probabilities are customizable fields you may use to reflect how likely you are to win a sale. The prospect probability contains the following:
 
 | Field | Type | Description |
@@ -98,7 +98,7 @@ Prospect probabilities are customizable fields you may use to reflect how likely
 
 
 
-## Get Prospect
+### Get Prospect
 > Sample Request:  
 
 ```http
@@ -117,10 +117,10 @@ curl -X get \
 
 This request returns a single prospect, identified by its `prospect_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [prospect object](#the-prospect-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be the single [prospect](#the-prospect-object) with its default fields and any additional fields requested via `_fields`.
 
 
@@ -129,7 +129,7 @@ The response will be the single [prospect](#the-prospect-object) with its defaul
 
 
 
-## List Prospects
+### List Prospects
 > Sample Request:  
 
 ```http
@@ -148,15 +148,15 @@ curl -X get \
 
 This request returns a list of prospects on the deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects from the [prospects object](#the-prospect-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-#### Basic Filters
+##### Basic Filters
 This request supports [basic filters](#filters-basic-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -173,7 +173,7 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | prospect_probability | Filter by the `prospect_probability`. |
 | company | Filter by the `company_id`. |
 
-#### Date Filters
+##### Date Filters
 This request supports [date filters](#filters-date-filters) over the following fields:
 
 | Filter Name |
@@ -183,7 +183,7 @@ This request supports [date filters](#filters-date-filters) over the following f
 | date_due |
 | date_modified |
 
-#### Order Filters
+##### Order Filters
 This request supports [order filters](#filters-order-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -198,7 +198,7 @@ This request supports [order filters](#filters-order-filters) over the following
 | status | Order by the `status_id`. |
 | standing ||
 
-#### Range Filters
+##### Range Filters
 This request supports [range filters](#filters-range-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -214,14 +214,14 @@ This request supports [range filters](#filters-range-filters) over the following
 | prospect_type | Range over the `prospect_type_id`. |
 | status | Range over the `status_id`. |
 
-#### Searching
+##### Searching
 This request supports the [`_search`](#configuring-the-response-searching) parameter to search over the following fields:
 
 | Filter Name |
 |:-|
 | title |
 
-### Handling the Response
+#### Handling the Response
 This request will return a list of [prospects](#the-prospect-object) with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters, filters, or searches used.
 
 
@@ -230,7 +230,7 @@ This request will return a list of [prospects](#the-prospect-object) with their 
 
 
 
-## Count Prospects
+### Count Prospects
 > Sample Request:  
 
 ```http
@@ -259,7 +259,7 @@ This request will return a count of prospects in a list defined by any available
 
 
 
-## Get Prospect Status
+### Get Prospect Status
 > Sample Request:  
 
 ```http
@@ -278,10 +278,10 @@ curl -X get \
 
 This request returns the [prospect status](#the-prospect-status) of a prospect, identified by its `prospect_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [prospect status object](#the-prospect-status) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be the single [prospect status](#the-prospect-status) with its default fields and any additional fields requested through `_fields`.
 
 
@@ -290,7 +290,7 @@ The response will be the single [prospect status](#the-prospect-status) with its
 
 
 
-## List Prospect Statuses
+### List Prospect Statuses
 > Sample Request:  
 
 ```http
@@ -309,15 +309,15 @@ curl -X get \
 
 This request returns a list of  [statuses](#statuses) for prospects on the deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects from the [status object](#statuses) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-#### Basic Filters
+##### Basic Filters
 This request supports the following [basic filters](#filters-basic-filters):
 
 | Filter Name |
@@ -327,7 +327,7 @@ This request supports the following [basic filters](#filters-basic-filters):
 | standing |
 | color |
 
-#### Order Filters
+##### Order Filters
 This request supports the following [order filters](#filters-order-filters):
 
 | Filter Name |
@@ -338,14 +338,14 @@ This request supports the following [order filters](#filters-order-filters):
 | color |
 | ordering |
 
-#### Searching
+##### Searching
 This request supports the [`_search`](#configuring-the-response-searching) parameter to search over the following fields:
 
 | Field |
 |:-|
 | title |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of prospect [statuses](#statuses) with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters, filters, or searches used.
 
 
@@ -354,7 +354,7 @@ The response will be a list of prospect [statuses](#statuses) with their default
 
 
 
-## List Prospect Types
+### List Prospect Types
 > Sample Request:  
 
 ```http
@@ -373,15 +373,15 @@ curl -X get \
 
 This request returns a list of [prospect types](#the-prospect-type) on the deployment.
 
-### Configuring the Request
+#### Configuring the Request
 
-#### Pagination
+##### Pagination
 This request supports all of the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects from the [prospect type](#the-prospect-type) object using the [`_fields`](#configuring-the-response-fields) parameter.
 
-#### Basic Filters
+##### Basic Filters
 This request supports the following [basic filters](#filters-basic-filters):
 
 | Filter |
@@ -389,7 +389,7 @@ This request supports the following [basic filters](#filters-basic-filters):
 | id |
 | standing |
 
-#### Order Filters
+##### Order Filters
 This request supports [order filters](#filters-order-filters) over the following fields:
 
 | Field |
@@ -399,14 +399,14 @@ This request supports [order filters](#filters-order-filters) over the following
 | standing |
 | ordering |
 
-#### Range Filters
+##### Range Filters
 This request supports [range filters](#filters-range-filters) over the following fields:
 
 | Field |
 |:-|
 | id |
 
-#### Searching
+##### Searching
 This request supports the [`_search`](#configuring-the-response-searching) parameter
 to search over the following fields:
 
@@ -414,7 +414,7 @@ to search over the following fields:
 |:-|
 | title |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [prospect types](#the-prospect-type) with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters used.
 
 
@@ -423,7 +423,7 @@ The response will be a list of [prospect types](#the-prospect-type) with their d
 
 
 
-## Update a Prospect
+### Update a Prospect
 > Sample Request:  
 
 ```http
@@ -444,7 +444,7 @@ curl -X get \
 
 This request updates and returns a [prospect](#the-prospect-object), specified by its `prospect_id`.
 
-### Configuring the Prospect
+#### Configuring the Prospect
 The following fields may be updated through this request:
 
 | Field Name | Notes |
@@ -458,10 +458,10 @@ The following fields may be updated through this request:
 
 See the [prospect object](#the-prospect-object) for more information on these fields.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [prospect object](#the-prospect-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be the single, updated [prospect object](#the-prospect-object) with its default fields and any additional fields requested through `_fields`.
 
 
@@ -470,7 +470,7 @@ The response will be the single, updated [prospect object](#the-prospect-object)
 
 
 
-## List Profile Fields
+### List Profile Fields
 > See the [profiles section](#retrieve-a-list-of-profile-fields for a sample request
 
 `GET /prospects/profiles/fields`
@@ -483,7 +483,7 @@ This request returns a list of [profile fields](#the-profile-field-object) avail
 
 
 
-## List Profile Field Values
+### List Profile Field Values
 > See the [profiles section](#retrieve-a-list-of-profile-values) for a sample request  
 
 `GET /prospects/{prospect_id}/profiles/values`
@@ -496,7 +496,7 @@ This request returns a list of [profile values](#the-profile-value-object) of a 
 
 
 
-## Update a Profile Field Value
+### Update a Profile Field Value
 > See the [profiles section](#update-a-profile-value-link) for a sample request  
 
 `PUT /prospects/{prospect_id}/profiles/values/{profile_value_id}`
@@ -510,7 +510,7 @@ This request updates and returns a [profile value](#the-profile-value-object), s
 
 
 
-## Set a Profile Field Value
+### Set a Profile Field Value
 > See the [profiles section](#create-a-profile-value-link) for a sample request
 
 `PUT|POST /prospects/{prospect_id}/profiles/fields/{profile_field_id}`
@@ -523,7 +523,7 @@ This request sets and returns a [profile value](#the-profile-value-object) for a
 
 
 
-## List Extension Fields
+### List Extension Fields
 > See the [extension section](#retrieve-a-list-of-extension-fields) for an example   
 
 `GET /prospects/extensions/fields`
@@ -536,7 +536,7 @@ This request returns a list of [extension fields](#the-extension-field-object) a
 
 
 
-## List Extension Field Values
+### List Extension Field Values
 > See the [extension section](#retrieve-a-list-of-extension-field-values) for an example    
 
 `GET /prospects/{prospect_id}/extensions/values`
@@ -549,7 +549,7 @@ This request returns a list of [extension values](#the-extension-value-object) f
 
 
 
-## Update an Extension Field Value
+### Update an Extension Field Value
 > See the [extension section](#update-an-extension-value) for an example    
 
 `PUT /prospects/{prospect_id}/extensions/values/{extension_value_id}`
@@ -562,7 +562,7 @@ This request updates the value of an [extension field value](#the-extension-valu
 
 
 
-## Set an Extension Field Value
+### Set an Extension Field Value
 > Sample Request:  
 
 `POST /prospects/{prospect_id}/extensions/fields/{extension_field_id}`
@@ -575,7 +575,7 @@ This request sets and returns the value of an extension field, specified by its 
 
 
 
-## List Available Progressions
+### List Available Progressions
 > See the [progressions section](#retrieve-a-list-of-available-progressions) for a sample request
 
 `GET /prospects/{prospect_id}/progressions`
@@ -588,7 +588,7 @@ This request returns a list of available [progressions](#the-progression-object)
 
 
 
-## Auto Run a Progression
+### Auto Run a Progression
 > See the [progressions section](#run-a-status-update-using-a-given-progression) for a sample request
 
 `PUT|POST /prospects/{prospect_id}/progressions/{progression_id}/auto`
@@ -601,7 +601,7 @@ This request uses the given progression, specified by its `progression_id` to pr
 
 
 
-## Retrieve a List of Resource Collections for a Prospect
+### Retrieve a List of Resource Collections for a Prospect
 > Sample Request:  
 
 `GET /prospects/{prospect_id}/collections`
@@ -614,7 +614,7 @@ This request returns a list of [resource collections](#resources-attachments) ag
 
 
 
-## Upload a Resource (Attachment) to a Collection of a Prospect
+### Upload a Resource (Attachment) to a Collection of a Prospect
 > Sample Request:  
 
 `POST /prospects/{prospect_id}/collections/{collection_id}/resources`

--- a/source/includes/endpoints/_purchases.md
+++ b/source/includes/endpoints/_purchases.md
@@ -1,11 +1,11 @@
-# Purchases
+## Purchases
 
 > Object URI:  
 `/api/v0/purchases`
 
 Track the purchases made when completing a [job](#jobs-projects), [issue](#issues) or [contract](#contracts). More information may be found on the [release blog](https://www.accelo.com/resources/blog/your-billing-simplified-introducing-the-new-purchases-module/).
 
-## The Purchase Object (Beta)
+### The Purchase Object (Beta)
 The purchase object contains the following fields:
 
 | Field | Type | Description |
@@ -24,7 +24,7 @@ The purchase object contains the following fields:
 
 
 
-## Get Purchase (Beta)
+### Get Purchase (Beta)
 `GET /purchases/{purchase_id}`
 > Sample request:
 
@@ -42,10 +42,10 @@ CURL -X get \
 
 This request returns a [purchase](#the-purchase-object-beta)) identified by its `purchase_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [purchase object](#the-purchase-object-beta)) using the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-### Handling the Response
+#### Handling the Response
 The response will be the [purchase](#the-purchase-object-beta)) with its default fields and any additional fields requested through `_fields`.
 
 
@@ -53,7 +53,7 @@ The response will be the [purchase](#the-purchase-object-beta)) with its default
 
 
 
-## List Purchases (Beta)
+### List Purchases (Beta)
 `GET /purchases`
 
 ```http
@@ -70,15 +70,15 @@ CURL -X get \
 
 This request returns a list of [purchases](#the-purchase-object-beta)) on the deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all of the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request also supports requesting additional fields and linked objects from the [purchase object](#the-purchase-object-beta)) using the [`_fields`](#configuring-the-response-fields) parameter, as well as [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-#### Basic Filters
+##### Basic Filters
 This request supports the following [basic filters](#filters-basic-filters):
 
 | Filter |
@@ -88,14 +88,14 @@ This request supports the following [basic filters](#filters-basic-filters):
 | creator_id |
 | affiliation_id |
 
-#### Date Filters
+##### Date Filters
 This request supports the following [date filters](#filters-date-filters):
 
 | Filter |
 |:-|
 | date_purchased |
 
-#### Order Filters
+##### Order Filters
 This request supports [order filters](#filters-order-filters) over the following fields:
 
 | Field |
@@ -108,7 +108,7 @@ This request supports [order filters](#filters-order-filters) over the following
 | creator_id |
 | affiliation_id |
 
-#### Range Filters
+##### Range Filters
 This request supports [range filters](#filters-range-filters) over the following fields:
 
 | Field |
@@ -121,14 +121,14 @@ This request supports [range filters](#filters-range-filters) over the following
 | creator_id |
 | affiliation_id |
 
-#### Searching
+##### Searching
 This request supports the [`_search`](#configuring-the-response-searching) parameter to search over teh following fields:
 
 | Field |
 |:-|
 | title |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [purchases](#the-purchase-object-beta)) with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters, filters, or searches used.
 
 
@@ -136,7 +136,7 @@ The response will be a list of [purchases](#the-purchase-object-beta)) with thei
 
 
 
-## Count Purchases (Beta)
+### Count Purchases (Beta)
 `GET /purchases/count`
 
 ```http

--- a/source/includes/endpoints/_quotes.md
+++ b/source/includes/endpoints/_quotes.md
@@ -1,10 +1,10 @@
-# Quotes
+## Quotes
 > Resource URI:  
 `/api/v0/quotes`
 
 Quotes in Accelo allow you to generate and edit your quotes and proposals. See the [support documentation](https://www.accelo.com/resources/help/guides/user/modules/sales/quotes/) for information on quotes.
 
-## The Quote Object
+### The Quote Object
 > Example quote object:
 
 ```json
@@ -74,7 +74,7 @@ The quote object contains the following:
 
 
 
-## Get Quote
+### Get Quote
 > Sample Request:
 
 ```http
@@ -93,10 +93,10 @@ curl -X get \
 
 This request returns a single [quote](#the-quote-object), identified by its `quote_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked resources from the [quote object](#the-quote-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be the single [quote object](#the-quote-object) with its default fields and any additional fields requested through `_fields`.
 
 
@@ -105,7 +105,7 @@ The response will be the single [quote object](#the-quote-object) with its defau
 
 
 
-## List Quotes
+### List Quotes
 > Sample Request:  
 
 ```http
@@ -124,15 +124,15 @@ curl -X get \
 
 This request returns a list of quotes on the deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Resources
+##### Additional Fields and Linked Resources
 This request supports requesting additional fields and linked resources from the [quote object](#the-quote-object) using the [`_fields`](#configuring-the-response-fields) paramter.
 
-#### Basic Filters
+##### Basic Filters
 This request supports [basic filters](#filters-basic-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -146,7 +146,7 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | against_id ||
 | created_by | Filter by the `created_by_staff_id`. |
 
-#### Date Filters
+##### Date Filters
 This request supports [date filters](#filters-date-filters) over the following fields:
 
 | Filter Name |
@@ -154,7 +154,7 @@ This request supports [date filters](#filters-date-filters) over the following f
 | date_created |
 | date_expiry |
 
-#### Order Filters
+##### Order Filters
 This request supports [order filters](#filters-order-filters) over the following fields:
 
 | Filter Name |
@@ -167,7 +167,7 @@ This request supports [order filters](#filters-order-filters) over the following
 | material_price_total |
 | total_price |
 
-#### Range Filters
+##### Range Filters
 This request supports [range filters](#range-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -183,21 +183,21 @@ This request supports [range filters](#range-filters) over the following fields:
 | material_price_total |
 | total_price ||
 
-#### Object Filters
+##### Object Filters
 This request supports the following [object filters](#filters-object-filters):
 
 | Filter | Description |
 |:-|:-|
 | against | Filter by quotes against these objects. |
 
-#### Searching
+##### Searching
 This request supports the [`_search`](#configuring-the-response-searching) request over the following fields:
 
 | Field |
 |:-|
 | title |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [quotes](#the-quote-object) with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters, filters, or searches used.
 
 
@@ -206,7 +206,7 @@ The response will be a list of [quotes](#the-quote-object) with their default fi
 
 
 
-## Count Quotes
+### Count Quotes
 > Sample Request:  
 
 ```http
@@ -235,7 +235,7 @@ This request will return a count of quotes in a list defined by any available se
 
 
 
-## Update a Quote
+### Update a Quote
 > Sample Request:  
 
 ```http
@@ -256,7 +256,7 @@ curl -X get \
 
 This request updates and returns a [quote](#the-quote-object), identified by its `quote_id`.
 
-### Configuring the Quote
+#### Configuring the Quote
 The following fields from the [quote object](#the-quote-object) may be updated with this request:
 
 | Filter Name | Notes |
@@ -271,10 +271,10 @@ The following fields from the [quote object](#the-quote-object) may be updated w
 | terms_and_conditions | Update the HTML of the `terms` of the published quote. |
 | client_portal_access | Update the `portal_access` field. |
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [quote object](#the-quote-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be the single, updated [quote](#the-quote-object) with its default fields and any additional fields requested through `_fields`
 
 
@@ -283,7 +283,7 @@ The response will be the single, updated [quote](#the-quote-object) with its def
 
 
 
-## Create a Quote
+### Create a Quote
 > Sample Request:  
 
 ```http
@@ -304,7 +304,7 @@ curl -X get \
 
 This request creates and returns a [quote](#the-quote-object).
 
-### Configuring the Quote
+#### Configuring the Quote
 This request accepts the same fields as [`PUT /quotes/{quote_id}`](#update-a-quote), with the addition of the following required fields:
 
 | Filter Name |
@@ -313,10 +313,10 @@ This request accepts the same fields as [`PUT /quotes/{quote_id}`](#update-a-quo
 | **against_id** |
 | **against_type** |
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [quote object](#the-quote-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be the single, created [quote object](#the-quote-object) with its default fields and any additional fields requested through `_fields`.
 
 
@@ -325,7 +325,7 @@ The response will be the single, created [quote object](#the-quote-object) with 
 
 
 
-## List Resource Collections
+### List Resource Collections
 > See the [resources (attachments) section](#retrieve-an-array-of-collections-for-an-object) for an example
 
 `GET /quotes/{quote_id}/collections`
@@ -338,7 +338,7 @@ This request returns a list of [resource collections](#resources-attachments) ag
 
 
 
-## Upload a Resource (Attachment)
+### Upload a Resource (Attachment)
 > See the [resources (attachments) section](#upload-a-resource-to-a-collection-of-an-object) for an example  
 
 `POST /quotes/{quote_id}/collections/{collection_id}/resources`

--- a/source/includes/endpoints/_rates.md
+++ b/source/includes/endpoints/_rates.md
@@ -1,10 +1,10 @@
-# Rates
+## Rates
 > Resource URI:  
 `/api/v0/rates`
 
 Rates define the hourly rate paid for work done. They may be set up and modified from the deployment, see the [support documentation](https://www.accelo.com/resources/help/faq/setup-rates/) for information.
 
-## The Rate Object
+### The Rate Object
 > Example rate object:
 
 ```json
@@ -33,7 +33,7 @@ The rate object contains the following:
 
 
 
-## Get Rate
+### Get Rate
 > Sample Request:  
 
 ```http
@@ -52,10 +52,10 @@ curl -X get \
 
 This request returns a [rate](#the-rate-object) specified by its `rate_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [rate object](#the-rate-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be the single [rate](#the-rate-object) with its default fields and any additional fields requested through `_fields`.
 
 
@@ -64,7 +64,7 @@ The response will be the single [rate](#the-rate-object) with its default fields
 
 
 
-## List Rates
+### List Rates
 > Sample Request:  
 
 ```http
@@ -83,15 +83,15 @@ curl -X get \
 
 This request returns a list of [rates](#the-rate-object) on the deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects from the [rate object](#the-rate-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [rates](#the-rate-object) with the default fields and any additional fields requested through `_fields`, displayed according to any pagination parameters used.
 
 
@@ -100,7 +100,7 @@ The response will be a list of [rates](#the-rate-object) with the default fields
 
 
 
-## Count Rates
+### Count Rates
 > Sample Request:  
 
 ```http

--- a/source/includes/endpoints/_requests.md
+++ b/source/includes/endpoints/_requests.md
@@ -1,10 +1,10 @@
-# Requests
+## Requests
 > Resource URI:  
 `/api/v0/requests`
 
 These allow you to track request from clients sent to your shared company addresses, such as "@support" or "@sales" addresses. See the [support documentation](https://www.accelo.com/resources/help/learn-the-basics/tickets-and-requests/request-basics/) for more information on requests.
 
-## The Request Object
+### The Request Object
 > Sample request object:
 
 ```json
@@ -49,7 +49,7 @@ The request object contains the following:
 | affiliation_id | unsigned | The unique identifier of the [affiliation](#affiliations) associated with the request. |
 | affiliation | unsigned or object | The [affiliation](#affiliations) associated with the request. |
 
-### The Request Type
+#### The Request Type
 > Example request type object:
 
 ```json
@@ -70,7 +70,7 @@ The request type object allows you to assign a type to each request, making them
 | **title** | string | A name for the request type. |
 | standing | select | The standing of the request type, either "active" or "inactive". |
 
-### The Request Priority
+#### The Request Priority
 Issue priorities help you keep track of what needs to be done. They may be set up from the deployment, they contain the following:
 
 | Field | Type | Description |
@@ -80,7 +80,7 @@ Issue priorities help you keep track of what needs to be done. They may be set u
 | color | select | The color of the priority when displayed on the deployment. The colors, in order of increasing urgency a "grey", "blue", "green", "orange", "red". |
 | factor | unsigned | A number representing the urgency of the priority. 5 is "Extreme", 1 is "None". |
 
-### Request Threads
+#### Request Threads
 > Sample request thread:
 
 ```json
@@ -141,7 +141,7 @@ Since request are communications made from the deployment, they each have an ass
 | **senders** | array | An array of senders of the original request, each defined by a "type" an an "id". |
 | **affiliation** | object | As in the [request object](#the-request-object). |
 
-### Request Thread Unresponded Counts
+#### Request Thread Unresponded Counts
 > Example object:
 
 ```json
@@ -170,7 +170,7 @@ These objects track the number of unresponded requests against each request type
 
 
 
-## Get Request
+### Get Request
 > Sample Request:  
 
 ```http
@@ -189,10 +189,10 @@ curl -X get \
 
 This request returns a [request](#the-request-object) specified by its `request_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked from the [request object](#the-request-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be the single [request](#the-request-object) with its default fields and any additional fields requested through `_fields`.
 
 
@@ -201,7 +201,7 @@ The response will be the single [request](#the-request-object) with its default 
 
 
 
-## List  Requests
+### List  Requests
 > Sample Request:  
 
 ```http
@@ -220,15 +220,15 @@ curl -X get \
 
 This request returns a list of [requests](#the-request-object) on the deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects from the [request object](#the-request-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-#### Basic Filters
+##### Basic Filters
 This request supports [basic filters](#filters-basic-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -241,14 +241,14 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | lead | Filter by the `lead_id`. |
 | claimer_id ||
 
-#### Date Filters
+##### Date Filters
 This request supports [date filters](#filters-date-filters) over the following fields:
 
 | Filter Name |
 |:-|
 | date_created |
 
-#### Order Filters
+##### Order Filters
 This request supports [order filters](#filters-order-filters) over the following fields:
 
 | Filter Name
@@ -256,7 +256,7 @@ This request supports [order filters](#filters-order-filters) over the following
 | id |
 | date_created |
 
-#### Range Filters
+##### Range Filters
 This request supports [range filters](#filters-range-filters) over the following fields:
 
 || Notes |
@@ -268,14 +268,14 @@ This request supports [range filters](#filters-range-filters) over the following
 | affiliation | Range over the `affiliation_id`. |
 | priority | Range over the `affiliation_id`. |
 
-### Searching
+#### Searching
 This request supports the [`_search`](#configuring-the-response-searching) parameter to search over the following fields:
 
 | Field |
 |:-|
 | title |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [requests](#the-request-object) with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters, filters, or searches used. s
 
 
@@ -284,7 +284,7 @@ The response will be a list of [requests](#the-request-object) with their defaul
 
 
 
-## Count Requests
+### Count Requests
 > Sample Request:  
 
 ```http
@@ -313,7 +313,7 @@ This request will return a count of requests in a list defined by any available 
 
 
 
-## List Request Threads
+### List Request Threads
 > Sample Request:  
 
 ```http
@@ -332,12 +332,12 @@ curl -X get \
 
 This request returns a list of [request threads](#request-threads) on the deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Basic Filters
+##### Basic Filters
 This request supports [basic filters](#filters-basic-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -346,14 +346,14 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | request_type_id | Filter by the `type_id`. |
 | interact_from_staff | Filter by the `staff_id` of staff who have interacted with the request. |
 
-#### Date Filters
+##### Date Filters
 This request supports [date filters](#filters-date-filters) over the following fields:
 
 | Filter Name |
 |:-|
 | date_created |
 
-#### Boolean Filters
+##### Boolean Filters
 this request also supports a special kind of filter, the boolean filter. These filters take boolean arguments, the supported filters are:
 
 | Filter Name | Notes |
@@ -363,7 +363,7 @@ this request also supports a special kind of filter, the boolean filter. These f
 | order_by_date_created | Whether to order in ascending order of `date_created`. |
 | order_by_desc_latest_external_interaction | Whether to order in ascending order of `date_last_external_interaction`. |
 
-#### List Unresponded Counts
+##### List Unresponded Counts
 
 > Sample request:
 
@@ -384,7 +384,7 @@ curl -X get \
 
 This request also supports a flag, `include_unresponded_counts` which may be either '0' or '1'. If set to '1' this returns an additional array, `unresponded_counts` 
 
-### Handling the Response
+#### Handling the Response
 The response will be an array of [request threads](#request-threads) labeled "requests", and an array of linked objects labeled "linked_objects". The "linked_objects" array is an array of objects linked to the requests in the "requests" array. Any filters used will be applied to the elements of the "request" array.
 
 
@@ -392,7 +392,7 @@ The response will be an array of [request threads](#request-threads) labeled "re
 
 
 
-## List Request Types (Beta)
+### List Request Types (Beta)
 > Sample Request:  
 
 ```shell
@@ -421,13 +421,13 @@ This request returns a list of `request_type` objects, which contain the followi
 
 Note this is different to the [request type](#the-request-type) object.
 
-### Handling the Response
+#### Handling the Response
 This request does not accept pagination, filtering, or searching. The response will be a list of `request_type` objects on the deployment.
 
 
 
 
-## Update a Request
+### Update a Request
 > Sample Request:  
 
 ```http
@@ -449,7 +449,7 @@ curl -X get \
 
 This request updates and returns a [request](#the-request-object) identified by its `request_id`.
 
-### Configuring the Request
+#### Configuring the Request
 Values for the following fields may be updated through this request:
 
 | Field Name |
@@ -464,10 +464,10 @@ Values for the following fields may be updated through this request:
 | standing |
 | claimer_id |
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [request object](#the-request-object) using the [`_fields`](#configuring-the-response-fields) parameter
 
-### Handling the Response
+#### Handling the Response
 The response will be the single, updated [request](#the-request-object) with its default fields and any additional fields requested through `_fields`.
 
 
@@ -476,7 +476,7 @@ The response will be the single, updated [request](#the-request-object) with its
 
 
 
-## Create a Request
+### Create a Request
 > Example request:
 
 ```shell
@@ -526,7 +526,7 @@ curl -X post \
 
 This request creates and returns a [request](#the-request-object). Since a request requires an affiliation, and request may not necessarily come from known contacts, using this request you may also create a contact/affiliation, [see](#handling-a-lack-of-affiliation).
 
-### Configuring the Request
+#### Configuring the Request
 The following fields may be set through this request:  
 
 | Field Name | Notes |
@@ -539,7 +539,7 @@ The following fields may be set through this request:
 | source | May either be "email" or "null". |
 | lead_id ||
 
-### Handling a Lack of Affiliation
+#### Handling a Lack of Affiliation
 If no [affiliation](#affiliations) data is available we will attempt to link the given data to a known affiliation, otherwise we will create one. There are three minimum sets of information we can use to create an affiliation:
 
 1. [A firstname and a surname](#requests-first-method)  
@@ -547,15 +547,15 @@ If no [affiliation](#affiliations) data is available we will attempt to link the
 3. [An email address](#requests-third-method)
 
 <a name="requests-first-method"></a>
-#### Given a Firstname and a Surname
+##### Given a Firstname and a Surname
 If an affiliation exists which exactly matches these two names, we will link it. Otherwise, we will create a company and contact with the name "`firstname` `surname`", and then create an affiliation to link the two.
 
 <a name="requests-second-method"></a>
-#### Given a Firstname and a Company Name
+##### Given a Firstname and a Company Name
 If there is no match the company name, a new company with this name will be used, then a contact under this company will be created using the firstname supplied, finally an affiliation will be created to link the two.
 
 <a name="requests-third-method"></a>
-#### Given an Email Address
+##### Given an Email Address
 If there is no match, we will attempt to extract a name from the email provided. Next, a company will be made with the provided email as the name, then a contact will be made under this company, whose name would be the name extracted from the email. Finally an affiliation would link the two.
 
 The following fields may be used to send this information:
@@ -596,8 +596,8 @@ The following fields may be used to send this information:
 
 You may also send contact and company information as a JSON payload. Ensure that the content type is set to `application/json` in this case. [For example](#create-request-json-example) here we have created a contact, company and affiliation in handling a request.
 
-### Configuring the Response
+#### Configuring the Response
 The request supports requesting additional fields and linked objects from the [request object](#the-request-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be the new, single, [request](#the-request-object) with its default fields and any fields requested through `_fields`.

--- a/source/includes/endpoints/_resources.md
+++ b/source/includes/endpoints/_resources.md
@@ -1,10 +1,10 @@
-# Resources (Attachments)
+## Resources (Attachments)
 > Resource URI:  
 `api/v0/resources`
 
 Resources (or attachments) are files uploaded to the deployment. Collections are used to group resources on the deployment, they are similar to a folder system for resources.
 
-## The Resource Object
+### The Resource Object
 > Example resource object:
 
 ```json
@@ -30,7 +30,7 @@ The resource object contains the details on an uploaded file:
 | owner_type | string | The type of object that uploaded the resource. |
 | owner_id | unsigned | The unique identifier of the object that uploaded the resource. |
 
-## The Collection Object
+### The Collection Object
 > Example collection object:
 
 ```json
@@ -55,7 +55,7 @@ The resource object contains the details on an uploaded file:
 
 
 
-## Get Resource
+### Get Resource
 > Sample Request:   
 
 ```http
@@ -74,10 +74,10 @@ curl -X get \
 
 This request returns a [resource](#the-resource-object) identified by its `resource_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [resource objects](#the-resource-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be the [resource](#the-resource-object) with its default fields and any additional fields requested through `_fields`.
 
 
@@ -86,7 +86,7 @@ The response will be the [resource](#the-resource-object) with its default field
 
 
 
-## List Resources
+### List Resources
 > Sample Request:   
 
 ```http
@@ -105,15 +105,15 @@ curl -X get \
 
   This request returns a list of [resources](#the-resource-object) on the deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all the [pagination](#configuring-the-response-pagination) requests.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects from the [resource object](#the-resource-object) using the `_fields` parameter.
 
-#### Basic Filters
+##### Basic Filters
 This request supports [basic filters](#filters-basic-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -123,14 +123,14 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | activity_id | Filter by the `activity_id` of the [activity](#activities) through which the resources was uploaded. |
 | collection_id | Filter by resources belonging to the collections with these IDs. |
 
-#### Date Filters
+##### Date Filters
 This request supports [date filters](#filters-date-filters) over the following fields:
 
 | Filter Name |
 |:-|
 | date_created |
 
-#### Order Filters
+##### Order Filters
 This request supports [order filters](#filters-order-filters) over the following fields:
 
 | Filter Name |
@@ -140,21 +140,21 @@ This request supports [order filters](#filters-order-filters) over the following
 | filesize |
 | mimetype |
 
-#### Object Filters
+##### Object Filters
 This request supports the following [object filters](#filters-object-filters):
 
 | Filter Name | Notes |
 |:-|:-|
 | owner | Filter by resources owned by these objects. | 
 
-#### Searching
+##### Searching
 This request supports the [`_search`](#configuring-the-response-searching) parameter to search over the following fields:
 
 | Field |
 |:-|
 | title |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [resources](#the-resource-object) with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters, filters, or searches used.
 
 
@@ -163,7 +163,7 @@ The response will be a list of [resources](#the-resource-object) with their defa
 
 
 
-## Count Resources
+### Count Resources
 > Sample Request:   
 
 ```http
@@ -191,7 +191,7 @@ This request will return a count of resources in a list defined by any available
 
 
 
-## List Collections for an Object
+### List Collections for an Object
 <a name="retrieve-an-array-of-collections-for-an-object"></a>
 > Sample Request:
 
@@ -211,12 +211,12 @@ curl -X get \
 
 This request returns a list of [collections](#the-collection-object) against an `object`, identified by its `object_id`.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all of the [pagination](#configuring-the-response-pagination) parameters.
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [collections](#the-collection-object) with their default fields, and displayed according to any pagination filters used.
 
 
@@ -226,7 +226,7 @@ The response will be a list of [collections](#the-collection-object) with their 
 
 
 <a name="upload-a-resource-to-a-collection-of-an-object"></a>
-## Upload a Resource to a Collection
+### Upload a Resource to a Collection
 > Sample Sample Request:
 
 ```http
@@ -255,14 +255,14 @@ curl -X post \
 
 This request uploads a file to a given collection, identified by its `collection_id`, of a particular object identified through `object` and `object_id`.
 
-### Configuring the Resource
+#### Configuring the Resource
 The file may be uploaded using the following parameter:
 
 | Field | Type | Description |
 |:-|:-|:-|
 | **resource** | file | The file to be uploaded. |
 
-### Handling the Response
+#### Handling the Response
 The response will contain the following fields:
 
 | Field | Type | Description |
@@ -277,7 +277,7 @@ The response will contain the following fields:
 
 
 
-## Download a Resource
+### Download a Resource
 > Sample Request:   
 
 ```http

--- a/source/includes/endpoints/_skills.md
+++ b/source/includes/endpoints/_skills.md
@@ -1,10 +1,10 @@
-# Skills
+## Skills
 > Resource URI:  
 `/api/v0/skills`
 
 Skills are tags assigned to tasks or users which can then be used to appropriately assign work. See the [support documentation](https://www.accelo.com/resources/blog/schedule-tasks-to-the-right-person-with-skills-tagging/) for more information skills and how to use them on the deployment.
 
-## The Skill Object
+### The Skill Object
 > Example skill object:
 
 ```json
@@ -28,7 +28,7 @@ The skills object contains the following:
 
 
 
-## List Skills
+### List Skills
 > Sample Request:   
 
 ```http
@@ -47,15 +47,15 @@ curl -X get \
 
 This request returns a list of [skills](#the-skill-object) on the deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Resource
+##### Additional Fields and Linked Resource
 This request supports requesting additional fields and linked resources from the [skill object](#the-skill-object) using the `_fields` parameter.
 
-#### Basic Filters
+##### Basic Filters
 This request supports basic filters over the following fields:
 
 | Filter Name |
@@ -63,21 +63,21 @@ This request supports basic filters over the following fields:
 | id |
 | title |
 
-#### Object Filters
+##### Object Filters
 This request supports the following [object filters](#filters-object-filters):
 
 | Filter Name | Description |
 |:-|:-|
 | against | Filter by skills applied to this object. |
 
-#### Searching
+##### Searching
 This request supports using the [`_search`](#configuring-the-response-searching) parameter to search over the following fields:
 
 | Field |
 |:-|
 | title |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [skills](#the-skill-object) with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters, filters, or searches used.
 
 
@@ -86,7 +86,7 @@ The response will be a list of [skills](#the-skill-object) with their default fi
 
 
 
-## Count Skills
+### Count Skills
 > Sample Request:   
 
 ```http
@@ -115,7 +115,7 @@ This request will return a count of skills in a list defined by any available se
 
 
 
-## Create a Skill
+### Create a Skill
 > Sample Request:   
 
 ```http
@@ -136,15 +136,15 @@ curl -X get \
 
 This request creates and returns a [skill](#the-skill-object).
 
-### Configuring the Skill
+#### Configuring the Skill
 This request supports setting the following fields from the [skill object](#the-skill-object):
 
 | Field Name |
 |:-|
 | **title** |
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked items from the [skill object](#the-skill-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be the single, created [skill](#the-skill-object) with its default fields and any additional fields requested through `_fields`.

--- a/source/includes/endpoints/_staff.md
+++ b/source/includes/endpoints/_staff.md
@@ -1,10 +1,10 @@
-# Staff
+## Staff
 > Resource URI:  
 `/api/v0/staff`
 
 Staff (or users) are the users registered on the Accelo deployment. They are the company's Accelo users, admins, professionals, and collaborators
 
-## The Staff Object
+### The Staff Object
 The staff object contains the following
 
 | Field | Type | Description |
@@ -28,7 +28,7 @@ The staff object contains the following
 
 
 
-## Get Staff
+### Get Staff
 > Sample Request:   
 
 ```http
@@ -47,10 +47,10 @@ curl -X get \
 
 This requests returns a [staff member](#the-staff-object), specified by their `staff_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [staff object](#the-staff-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response is the single [staff object](#the-staff-object) with its default fields and any additional fields requested through `_fields`.
 
 
@@ -59,7 +59,7 @@ The response is the single [staff object](#the-staff-object) with its default fi
 
 
 
-## Get Current Staff
+### Get Current Staff
 > Sample Request:   
 
 ```http
@@ -84,7 +84,7 @@ This request returns the [staff object](#the-staff-object) for the current staff
 
 
 
-## List Staff
+### List Staff
 > Sample Request:   
 
 ```http
@@ -103,15 +103,15 @@ curl -X get \
 
 This request returns a list of [staff members](#the-staff-object) on the deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects from the [staff object](#the-staff-object) using the [`_fields`](#configuring-the-response-fields).
 
-#### Basic Filters
+##### Basic Filters
 This request supports [basic filters](#filters-basic-filters) over the following fields:
 
 | Filter Name |
@@ -121,7 +121,7 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | standing |
 | username |
 
-#### Range Filters
+##### Range Filters
 This request supports [range filters](#filters-range-filters) over the following fields:
 
 | Filter Name |
@@ -129,7 +129,7 @@ This request supports [range filters](#filters-range-filters) over the following
 | id |
 | rate |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [staff objects](#the-staff-object) with their default fields and any additional fields requested through `_fields`, displayed according to any pagination parameters or filters used.
 
 
@@ -138,7 +138,7 @@ The response will be a list of [staff objects](#the-staff-object) with their def
 
 
 
-## Count Staff
+### Count Staff
 > Sample Request:   
 
 ```http
@@ -167,7 +167,7 @@ This request will return a count of staff in a list defined by any available sea
 
 
 
-## Update a Staff Member
+### Update a Staff Member
 > Sample Request:   
 
 ```http
@@ -188,7 +188,7 @@ curl -X get \
 
 This request updates and returns a [staff member](#the-staff-object), identified by their `staff_id`.
 
-### Configuring the Staff
+#### Configuring the Staff
 The following fields from the [staff object](#the-staff-object) may be updated with this Sample Request:
 
 | Field Name |
@@ -202,10 +202,10 @@ The following fields from the [staff object](#the-staff-object) may be updated w
 | mobile |
 | position |
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [staff object](#the-staff-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be the update [staff object](#the-staff-object) with its default fields and any additional fields requested through `_fields`.
 
 
@@ -214,7 +214,7 @@ The response will be the update [staff object](#the-staff-object) with its defau
 
 
 
-## Create a Staff Member
+### Create a Staff Member
 > Sample Request:   
 
 ```http
@@ -235,7 +235,7 @@ curl -X get \
 
 This request creates and returns a new [staff member](#the-staff-object).
 
-### Configuring the Staff
+#### Configuring the Staff
 The following fields from the [staff object](#the-staff-object) may be set through this Sample Request:
 
 | Field Name | Notes |
@@ -251,10 +251,10 @@ The following fields from the [staff object](#the-staff-object) may be set throu
 | mobile ||
 | position ||
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [staff object](#the-staff-object) using the `_fields` parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be the single, updated [staff object](#the-staff-object) with its default fields and any additional fields requested through `_fields`.
 
 
@@ -263,7 +263,7 @@ The response will be the single, updated [staff object](#the-staff-object) with 
 
 
 
-## Delete a Staff Member
+### Delete a Staff Member
 > Sample Request:   
 
 ```http
@@ -288,7 +288,7 @@ This request removes a [staff member](#the-staff-object) from the deployment, id
 
 
 
-## List Profile Fields
+### List Profile Fields
 > See the [profiles section](#retrieve-a-list-of-profile-fields) for a sample request  
 
 `GET /staff/profiles/fields`
@@ -301,7 +301,7 @@ This request returns a list of [profile fields](#the-profile-field-object) avail
 
 
 
-## List Profile Field Values
+### List Profile Field Values
 > See the [profiles section](#retrieve-a-list-of-profile-values) for a sample request
 
 `GET /staff/{staff_id}/profiles/values`
@@ -314,7 +314,7 @@ This request returns a list of [profile values](#the-profile-value-object) of a 
 
 
 
-## Update a Profile Field Value
+### Update a Profile Field Value
 > See the [profiles section](#update-a-profile-value-link) for a sample request  
 
 `PUT /staff/{staff_id}/profiles/fields/{profile_value_id}`
@@ -328,7 +328,7 @@ This request updates and returns a [profile value](#the-profile-value-object), s
 
 
 
-## Set a Profile Field Value
+### Set a Profile Field Value
 > See the [profiles section](#create-a-profile-value-link) for a sample request 
 
 `PUT|POST /staff/{staff_id}/profiles/fields/{profile_field_id}`

--- a/source/includes/endpoints/_statuses.md
+++ b/source/includes/endpoints/_statuses.md
@@ -1,7 +1,7 @@
-# Statuses
+## Statuses
 Statuses are used to track the progress of work. See the [support documentation](https://www.accelo.com/resources/help/faq/automating-your-business-processes/statuses/) for more information. Since many resources on Accelo track various types and aspects of work, statuses are present in many different resources.
 
-## Status Objects
+### Status Objects
 The a status object may contain the following:
 
 | Fields | Type | Description |

--- a/source/includes/endpoints/_tags.md
+++ b/source/includes/endpoints/_tags.md
@@ -1,10 +1,10 @@
-# Tags
+## Tags
 > Resource URI:  
 `/api/v0/tags`
 
 Tags are keywords you my apply to a range of objects within Accelo, for example [activities](#activities) or [jobs](#jobs). They may both help describe the object, and make searching easier. See the [support documentation](https://www.accelo.com/resources/help/guides/user/activities-and-tasks/activities-notes-and-emails/set-up-and-customize/tags/) for more information on tags and how to apply them.
 
-## The Tag Object
+### The Tag Object
 The tag object contains the following:
 
 | Fields | Type | Description |
@@ -18,7 +18,7 @@ The tag object contains the following:
 
 
 
-## List Tags
+### List Tags
 > Sample Request:  
 
 ```http
@@ -37,15 +37,15 @@ curl -X get \
 
 This request returns a list of [tags](#the-tag-object) on the deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Resources
+##### Additional Fields and Linked Resources
 This request supports requesting additional fields and linked resources from the [tag object](#the-tag-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-#### Basic Filters
+##### Basic Filters
 This request supports basic filters over the following fields:
 
 | Filter Name |
@@ -53,21 +53,21 @@ This request supports basic filters over the following fields:
 | id |
 | name |
 
-#### Object Filters
+##### Object Filters
 This request supports the following [object filters](#filters-object-filters):
 
 | Filter Name | Description |
 |:-|:-|
 | against | Filter by tags applied to this object. |
 
-#### Searching
+##### Searching
 This request supports the [`_search`](#configuring-the-response-searching) parameter to search over the following fields:
 
 | Field Name |
 |:-|
 | name |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [tags](#the-tag-object) with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters, filters, or searches used.
 
 
@@ -76,7 +76,7 @@ The response will be a list of [tags](#the-tag-object) with their default fields
 
 
 
-## Count Tags
+### Count Tags
 > Sample Request:  
 
 ```http
@@ -105,7 +105,7 @@ This request will return a count of tags in a list defined by any available sear
 
 
 
-## Create a Tag
+### Create a Tag
 > Sample Request:  
 
 ```http
@@ -126,15 +126,15 @@ curl -X get \
 
 This request creates and returns a [tag](#the-tag-object).
 
-### Configuring the Tag
+#### Configuring the Tag
 The following fields from the [tag object](#the-tag-object) may be set with this request:
 
 | Field Name |
 |:-|
 | name |
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [tag object](#the-tag-object) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be the single, created [tag](#the-tag-object) with its default fields and any additional fields request through `_fields`.

--- a/source/includes/endpoints/_tasks.md
+++ b/source/includes/endpoints/_tasks.md
@@ -1,10 +1,10 @@
-# Tasks
+## Tasks
 > Resource URI:  
 `/api/v0/tasks`
 
 Tasks are small units of work, they may be thought of as the type of work you would put on a "to-do" list. See the [support documentation](https://www.accelo.com/resources/help/guides/user/activities-and-tasks/tasks/) for more information on tasks and how to interact with them on the deployment.
 
-## The Task Object
+### The Task Object
 The task object contains the following:
 
 | Field | Type | Description |
@@ -45,7 +45,7 @@ The task object contains the following:
 | milestone | unsigned or object | The [milestone](#milestones) object the task is against, if any. |
 | task_object_budget | unsigned or object | The [object budget](#object-budgets) linked to the task, if any.
 
-### The Task Type
+#### The Task Type
 Task types allow you to assign type labels to tasks. The task type contains the following:
 
 | Field | Type | Description |
@@ -57,10 +57,10 @@ Task types allow you to assign type labels to tasks. The task type contains the 
 
 Note: This object does not support the `_ALL` argument when request with [`_fields`](#configuring-the-response-fields).
 
-### The Task Metadata
+#### The Task Metadata
 The metadata object associated with [tasks](#the-task-object) is a list of the following:
 
-#### Task Metadata Managers
+##### Task Metadata Managers
 This is a list of [staff members](#staff) managing tasks on the deployment, the object has the following fields:
 
 | Field | Type | Description |
@@ -69,10 +69,10 @@ This is a list of [staff members](#staff) managing tasks on the deployment, the 
 | **name** | string | The staff member's full name (first name and surname). |
 | **email** | string | The staff member's email address. |
 
-#### Task Metadata Assignees
+##### Task Metadata Assignees
 This is a list of [staff members](#staff) assigned to tasks on the deployment. The object contains the same fields as the [managers metadata object](#task-metadata-managers)
 
-#### Task Metadata Against
+##### Task Metadata Against
 This is a list of object types that have tasks listed against them on the deployment, this object contains the following:
 
 | Field | Type | Description |
@@ -80,7 +80,7 @@ This is a list of object types that have tasks listed against them on the deploy
 | **id** | string | An identifier to identify the object within the API. For example "prospect".|
 | **name** | string | A name for the object. For example "Sale". |
 
-#### Task Metadata Status
+##### Task Metadata Status
 This is a list of [status](#statuses) objects available to tasks on the deployment. Note that this is a status object without the `start` field.
 
 
@@ -89,7 +89,7 @@ This is a list of [status](#statuses) objects available to tasks on the deployme
 
 
 
-## Get Task
+### Get Task
 > Sample Request:   
 
 ```http
@@ -108,10 +108,10 @@ curl -X get \
 
 This request returns a single [task](#the-task-object), identified by its `task_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [task object](#the-task-object) using the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-### Handling the Response
+#### Handling the Response
 The response will be the single [task object](#the-task-object) with its default fields and any additional fields requested through `_fields`.
 
 
@@ -120,7 +120,7 @@ The response will be the single [task object](#the-task-object) with its default
 
 
 
-## List Tasks
+### List Tasks
 > Sample Request:   
 
 ```http
@@ -139,15 +139,15 @@ curl -X get \
 
 This request returns a list of [tasks](#the-task-object) on the deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects from the [task object](#the-task-object) using the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-#### Basic Filters
+##### Basic Filters
 This request supports [basic filters](#filters-basic-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -163,7 +163,7 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | child_of_job | Filter by the `job_id` of the [job](#jobs-projects) the task, or its against object, is against. This allows you to find tasks under a certain job, even when they are not created directly against that job, for example if they are created against a [milestone](#milestones) under the job. |
 
 
-#### Date Filters
+##### Date Filters
 This request supports [date_filters](#filters-date-filters) over the following fields:
 
 | Filter Name |
@@ -176,7 +176,7 @@ This request supports [date_filters](#filters-date-filters) over the following f
 | date_modified |
 | date_due |
 
-#### Range Filters
+##### Range Filters
 This request supports [range filters](#filters-range-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -195,7 +195,7 @@ This request supports [range filters](#filters-range-filters) over the following
 | manager | Range over the `staff_id` of the manager. |
 | contact | Range over the `contact_id` of the associated contact. |
 
-#### Order Filters
+##### Order Filters
 This request supports [order filters](#filters-order-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -212,7 +212,7 @@ This request supports [order filters](#filters-order-filters) over the following
 | standing ||
 | status | Order by the `status_id`. |
 
-#### Object Filters
+##### Object Filters
 This request supports the following [object filters](#filters-object-filters):
 
 | Filter Name | Description |
@@ -220,7 +220,7 @@ This request supports the following [object filters](#filters-object-filters):
 | against | Filter by tasks against these objects. |
 | creator | Filter by tasks created by these objects. |
 
-#### Searching
+##### Searching
 This request supports the [`_search`](#configuring-the-response-searching) parameter to search over the following fields:
 
 | Field |
@@ -228,7 +228,7 @@ This request supports the [`_search`](#configuring-the-response-searching) param
 | description |
 | title |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [tasks](#the-task-object) with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters, filters, or searches used.
 
 
@@ -237,7 +237,7 @@ The response will be a list of [tasks](#the-task-object) with their default fiel
 
 
 
-## Count Tasks
+### Count Tasks
 > Sample Request:   
 
 ```http
@@ -266,7 +266,7 @@ This request will return a count of tasks in a list defined by any available sea
 
 
 
-## List Task Statuses
+### List Task Statuses
 > Sample Request:   
 
 ```http
@@ -285,15 +285,15 @@ curl -X get \
 
 This request returns a list of [statuses](#statuses) available for [tasks](#the-task-object) on the deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects from the [statuses](#statuses) object using the [`_fields`](#configuring-the-response-fields) parameter. Note, this request does not support the `_ALL` argument. Note, the status object for tasks does not contain the `start` field.
 
-#### Basic Filters
+##### Basic Filters
 This request supports the following [basic filters](#filters-basic-filters):
 
 | Filter Name |
@@ -303,7 +303,7 @@ This request supports the following [basic filters](#filters-basic-filters):
 | standing |
 | color |
 
-#### Order Filters
+##### Order Filters
 This request supports the following [order filters](#filters-order-filters):
 
 | Filter Name |
@@ -314,7 +314,7 @@ This request supports the following [order filters](#filters-order-filters):
 | color |
 | ordering |
 
-#### Searching
+##### Searching
 This request supports the [`_search`](#configuring-the-response-searching) parameter to search over the following fields:
 
 | Field |
@@ -322,7 +322,7 @@ This request supports the [`_search`](#configuring-the-response-searching) param
 | title |
 
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [statuses](#statuses) with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters, filters or searches used.
 
 
@@ -331,7 +331,7 @@ The response will be a list of [statuses](#statuses) with their default fields a
 
 
 
-## List Meta Data
+### List Meta Data
 > Sample Request:   
 
 ```http
@@ -350,7 +350,7 @@ curl -X get \
 
 This request returns a list of [metadata objects](#the-task-metadata) for [tasks](#the-task-object) on the deployment. That is, a list of lists.
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [task managers](#task-metadata-managers), [task assignees](#task-metadata-assignees), [against objects](#task-metadata-against), and [statuses](#task-metadata-status).
 
 
@@ -359,7 +359,7 @@ The response will be a list of [task managers](#task-metadata-managers), [task a
 
 
 
-## Update a Task
+### Update a Task
 > Sample Request:   
 
 ```http
@@ -380,7 +380,7 @@ curl -X get \
 
 This request updates and return a [task](#the-task-object) on the deployment.
 
-### Configuring the Task
+#### Configuring the Task
 The following fields from the [task object](#the-task-object) may be updated through this Sample Request:
 
 | Field Name |
@@ -396,10 +396,10 @@ The following fields from the [task object](#the-task-object) may be updated thr
 | date_due |
 | remaining |
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked resources from the [task object](#the-task-object) using the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-### Handling the Response
+#### Handling the Response
 The response will be the single, updated [task](#the-task-object) with its default fields and any additional fields requested through `_fields`.
 
 
@@ -408,7 +408,7 @@ The response will be the single, updated [task](#the-task-object) with its defau
 
 
 
-## Create a Task
+### Create a Task
 > Sample Request:   
 
 ```http
@@ -429,7 +429,7 @@ curl -X get \
 
 This request creates and returns a [task](#the-task-object).
 
-### Configuring the Task
+#### Configuring the Task
 The following fields from the [task object](#the-task-object) may be set with this Sample Request:
 
 | Field Name | Notes |
@@ -449,10 +449,10 @@ The following fields from the [task object](#the-task-object) may be set with th
 | rate_charged | Only available if the task is against a "job" or "milestone". The rate charged for work on this task, as a decimal. |
 | is_billable | Only available if the task is against a "job" or "milestone". Whether this task is billable, may either by "yes" or "no". |
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [task object](#the-task-object) using the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-### Handling the Response
+#### Handling the Response
 The response will be the single, created [task](#the-task-object) with its default fields and any additional fields requested through `_fields`.
 
 
@@ -461,7 +461,7 @@ The response will be the single, created [task](#the-task-object) with its defau
 
 
 
-## List Available Progressions
+### List Available Progressions
 > See the [progressions section](#retrieve-a-list-of-available-progressions) for a sample request
 
 `GET /tasks/{task_id}/progressions`
@@ -474,7 +474,7 @@ This request returns a list of available [progressions](#the-progression-object)
 
 
 
-## Auto Run a Progression
+### Auto Run a Progression
 > See the [progressions section](#run-a-status-update-using-a-given-progression) for a sample request 
 
 `PUT|POST /tasks/{task_id}/progressions/{progression_id}/auto`
@@ -487,7 +487,7 @@ This request uses the given progression, specified by its `progression_id` to pr
 
 
 
-## Auto Progress to Start or End
+### Auto Progress to Start or End
 > Requests:  
 
 `PUT|POST /tasks/{task_id}/progressions/start`  

--- a/source/includes/endpoints/_taxes.md
+++ b/source/includes/endpoints/_taxes.md
@@ -1,7 +1,7 @@
-# Taxes
+## Taxes
 The different account tax codes are stored by Accelo in the tax object. For information on these, and instructions on interacting with them through the deployment please see the [support doucmentation](https://www.accelo.com/resources/help/guides/settings-and-configuration-guide/modules/billing-and-invoices/tax-codes/)
 
-## The Tax Object (Beta)
+### The Tax Object (Beta)
 > Example tax:
 
 ```json
@@ -27,7 +27,7 @@ The tax object contains the following:
 
 
 
-## Get Tax (Beta)
+### Get Tax (Beta)
 
 ```http
 GET /api/v0/taxes/{tax_id} HTTP/1.1
@@ -45,10 +45,10 @@ curl -X GET \
 
 This request returns a [tax object](#the-tax-object-beta) specified by its `tax_id`
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [tax object](#the-tax-object-beta) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-### Handling the Response
+#### Handling the Response
 The response will be the single tax object with its default fields and any additional fields requested through `_fields`.
 
 
@@ -56,7 +56,7 @@ The response will be the single tax object with its default fields and any addit
 
 
 
-## List Taxes (Beta)
+### List Taxes (Beta)
 
 ```http
 GET /api/v0/taxes HTTP/1.1
@@ -74,15 +74,15 @@ curl -X GET \
 
 This request returns a list of [taxes](#the-tax-object-beta).
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all the standard [pagination parameters](#configuring-the-response-pagination).
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects from the [tax object](#the-tax-object-beta) using the [`_fields`](#configuring-the-response-fields) parameter.
 
-#### Basic Filters
+##### Basic Filters
 This request supports the following [basic filters](#filters-basic-filters):
 
 | Filter |
@@ -90,7 +90,7 @@ This request supports the following [basic filters](#filters-basic-filters):
 | id |
 | standing |
 
-#### Order Filters
+##### Order Filters
 This request supports the following [order filters](#filters-order-filters):
 
 | Filter |
@@ -99,14 +99,14 @@ This request supports the following [order filters](#filters-order-filters):
 | standing |
 | title |
 
-#### Range Filters
+##### Range Filters
 This request supports the following [range filters](#filters-range-filters):
 
 | Filter |
 |:-|
 | id |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [taxes](#the-tax-object-beta) with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters or filters used.
 
 
@@ -114,7 +114,7 @@ The response will be a list of [taxes](#the-tax-object-beta) with their default 
 
 
 
-## Count Taxes (Beta)
+### Count Taxes (Beta)
 
 ```http
 GET /api/v0/taxes/count HTTP/1.1

--- a/source/includes/endpoints/_timers.md
+++ b/source/includes/endpoints/_timers.md
@@ -1,4 +1,4 @@
-# Timers
+## Timers
 > Resource URI:  
 `/api/v0/timers`
 
@@ -6,7 +6,7 @@ Timers are used to log time through Accelo. See the [support documentation](http
 
 **NOTE:** Timer endpoints all operate from the current user and because of this are **not available to service applications**. If this restriction impacts your business model, please contact support and we will consider opening certain timer access up to service applications by requiring a staff id. It also means that a user will only be able to view or edit timers that they own.
 
-## The Timer Object
+### The Timer Object
 The timer object contains the following:
 
 | Field | Type | Description |
@@ -27,7 +27,7 @@ The timer object contains the following:
 
 
 
-## Get Timer
+### Get Timer
 > Sample Request:   
 
 ```http
@@ -46,10 +46,10 @@ curl -X get \
 
 This request returns a [timer](#the-timer-object) identified by its `timer_id`.
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [timer object](#the-timer-object) using the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-### Handling the Response
+#### Handling the Response
 The response will be the [timer](#the-timer-object) with its default fields and any additional fields requested through `_fields`.
 
 
@@ -58,7 +58,7 @@ The response will be the [timer](#the-timer-object) with its default fields and 
 
 
 
-## List Timers
+### List Timers
 > Sample Request:   
 
 ```http
@@ -77,15 +77,15 @@ curl -X get \
 
 This request returns a list of [timers](#the-timer-object) on the deployment.
 
-### Configuring the Response
+#### Configuring the Response
 
-#### Pagination
+##### Pagination
 This request supports all the [pagination](#configuring-the-response-pagination) parameters.
 
-#### Additional Fields and Linked Objects
+##### Additional Fields and Linked Objects
 This request supports requesting additional fields and linked objects from the [timer objects](#the-timer-object) using the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-#### Basic Filters
+##### Basic Filters
 This request supports [basic filters](#filters-basic-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -94,7 +94,7 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | staff | Filter by the `staff_id`. |
 | status ||
 
-#### Range Filters
+##### Range Filters
 This request supports [range filters](#filters-range-filters) over the following fields:
 
 | Filter Name | Notes |
@@ -103,7 +103,7 @@ This request supports [range filters](#filters-range-filters) over the following
 | against_id ||
 | staff | Range by the `staff_id`. |
 
-### Handling the Response
+#### Handling the Response
 The response will be a list of [timers](#the-timer-object) with their default fields and any additional fields requested through `_fields`, and displayed according to any pagination parameters or filters used.
 
 
@@ -112,7 +112,7 @@ The response will be a list of [timers](#the-timer-object) with their default fi
 
 
 
-## Update a Timer
+### Update a Timer
 > Sample Request:   
 
 ```http
@@ -133,7 +133,7 @@ curl -X get \
 
 This request updates and returns a [timer](#the-timer-object) identified by its `timer_id`.
 
-### Configuring the Timer
+#### Configuring the Timer
 The following fields from the [timer objects](#the-timer-object) may be updated through this Sample Request:
 
 | Field Name | Notes |
@@ -143,10 +143,10 @@ The following fields from the [timer objects](#the-timer-object) may be updated 
 | against_id ||
 | seconds | Can only be updated for stopped timers. |
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [timer object](#the-timer-object) using the `_fields` parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-### Handling the Response
+#### Handling the Response
 The response is the single, updated [timer](#the-timer-object) with its default fields and any additional fields requested through `_fields`
 
 
@@ -155,7 +155,7 @@ The response is the single, updated [timer](#the-timer-object) with its default 
 
 
 
-## Create a Timer
+### Create a Timer
 > Sample Request:   
 
 ```http
@@ -176,7 +176,7 @@ curl -X get \
 
 This request creates and returns a [timer](#the-timer-object).
 
-### Configuring the Timer
+#### Configuring the Timer
 The following fields may be set through this Sample Request:
 
 | Field Name | Notes |
@@ -187,10 +187,10 @@ The following fields may be set through this Sample Request:
 | seconds ||
 | auto_start | May be either "1" or "0", whether the timer starts upon creation. If it starts, it will stop any current timers. The default is "0". |
 
-### Configuring the Response
+#### Configuring the Response
 This request supports requesting additional fields and linked objects from the [timer object](#the-timer-object) through the [`_fields`](#configuring-the-response-fields) parameter. This request also supports [breadcrumbs](#configuring-the-response-breadcrumbs).
 
-### Handling the Response
+#### Handling the Response
 The response will be the single, created, [timer](#the-timer-object) with its default fields and any additional fields requested through `_fields`
 
 
@@ -199,7 +199,7 @@ The response will be the single, created, [timer](#the-timer-object) with its de
 
 
 
-## Delete a Timer
+### Delete a Timer
 > Sample Request:
 
 ```http
@@ -224,7 +224,7 @@ This request deletes a [timer](#the-timer-object), specified by its `timer_id`. 
 
 
 
-## Pause a Timer
+### Pause a Timer
 > Sample Request:   
 
 ```http
@@ -249,7 +249,7 @@ This request pauses and returns a [timer](#the-timer-object) identified by its `
 
 
 
-## Start a Timer
+### Start a Timer
 > Sample Request:   
 
 ```http
@@ -274,7 +274,7 @@ This request starts and returns a [timer](#the-timer-object) identified by its `
 
 
 
-## Cancel a Timer
+### Cancel a Timer
 > Sample Request:   
 
 ```http

--- a/source/includes/endpoints/_user.md
+++ b/source/includes/endpoints/_user.md
@@ -1,7 +1,7 @@
-# User
+## User
 This resource contains information about the current user, their deployment, and access token.
 
-## The User Object
+### The User Object
 The user object contains the same fields as the [staff](#staff) object, as well as the following:
 
 | Field | Type | Description |
@@ -15,5 +15,5 @@ The user object contains the same fields as the [staff](#staff) object, as well 
 
 
 
-## GET /user
+### GET /user
 This request returns a [user object](#the-user-object), it takes no parameters.

--- a/source/includes/endpoints/_webhooks.md
+++ b/source/includes/endpoints/_webhooks.md
@@ -1,4 +1,4 @@
-# Webhooks
+## Webhooks
 > Resource URI:  
 `api/v0/webhooks`
 
@@ -6,9 +6,9 @@ Webhooks allow you to build integrations that subscribe to specific Accelo event
 
 There's currently no limit on webhooks and they can be installed per deployment from an individual users account using the webhooks control panel. See [our blog](https://www.accelo.com/resources/updates/2016-nov-27-dec-3/#webhooks) for more information, and how to access webhooks on the deployment. We do enforce a 10 second timeout rule. If your trigger URL takes more than 10 seconds to respond to webhook delivery, we will cancel the request. If this occurs too many times, we will delete your webhook subscription automatically.
 
-## Webhook Subscriptions
+### Webhook Subscriptions
 
-### Webhook Events
+#### Webhook Events
 When subscribing to webhooks you choose an event that you would like to receive payloads for. Each event corresponds to a certain set of actions on a per object basis. The available events are:
 
 | event_id | Description |
@@ -19,7 +19,7 @@ When subscribing to webhooks you choose an event that you would like to receive 
 | create_request | Any time a new [request](#requests) is created. |
 | update_request_status | Any time a request status changes. |
 
-#### Progression Webhooks
+##### Progression Webhooks
 
 [Progression webhooks](https://www.accelo.com/resources/blog/product-priorities-update-q2-of-2017/#progressionwebhooks]) 
 allow you to subscribe to changing statuses for companies, contacts, 
@@ -33,7 +33,7 @@ functionality to the api.
 ![Add Webhook Progression Form](../images/screenshots/add-progression-webhook-form.png)
 [Create Progression Webhook Form]
 
-### Payloads
+#### Payloads
 The payload sent to the callback URL will contain the following:
 
 | Field | Type | Description |
@@ -42,7 +42,7 @@ The payload sent to the callback URL will contain the following:
 | **resource_url** | string | The full URL of the object changed. |
 
 
-### Delivery Headers
+#### Delivery Headers
 As well as the information in the  [payload body](#payloads), the headers of HTTP request sent to  the payload URL will contain special headers:
 
 | Header | Description |
@@ -51,7 +51,7 @@ As well as the information in the  [payload body](#payloads), the headers of HTT
 | X-Hub-Signature | HMAC hex digest of the payload using your configured subscriptions secret. |
 
 
-### The Webhook Subscription
+#### The Webhook Subscription
 The webhook subscription object contains the following:
 
 | Field | Type | Description |
@@ -64,7 +64,7 @@ The webhook subscription object contains the following:
 | **user_deployment** | string | The user's deployment in the form `{deployment}`. |
 | **user_id** | unsigned | The current user's unique identifier, that is, their `staff_id`. |
 
-### Webhook Subscription Types
+#### Webhook Subscription Types
 Each webhook subscription is of a certain type, defined by the following fields from the [webhook subscription object](#webhook-subscriptions):
 
 | Field |
@@ -75,7 +75,7 @@ Each webhook subscription is of a certain type, defined by the following fields 
 | **trigger_type** |
 
 
-### Unsubscribing
+#### Unsubscribing
 Your integration can tell Accelo to automatically unsubscribe by responding with a HTTP Status Gone 410. The dispatcher will respect this and instantly remove the subscription that caused the webhook trigger. Alternatively you can use the [delete subscription endpoint](#delete-webhook-subscription) mentioned below.
 
 
@@ -84,7 +84,7 @@ Your integration can tell Accelo to automatically unsubscribe by responding with
 
 
 
-## List Webhook Subscriptions
+### List Webhook Subscriptions
 > Sample Request:  
 
 ```http
@@ -109,7 +109,7 @@ This request returns a list of [webhook subscriptions](#webhook-subscriptions) f
 
 
 
-## List Webhook Subscription Types
+### List Webhook Subscription Types
 > Sample Request:  
 
 ```http
@@ -134,7 +134,7 @@ This request returns a list of  available [webhook subscription types](#webhook-
 
 
 
-## Create Webhook Subscription
+### Create Webhook Subscription
 > Sample Request:  
 
 ```http
@@ -155,7 +155,7 @@ curl -X get \
 
 This request creates and returns a [webhook subscription](#webhook-subscriptions) for the current user. This request takes no parameters to configure the response.
 
-### Configuring the Subscription
+#### Configuring the Subscription
 The following fields may be set through this Sample Request:  
 
 || Notes |
@@ -171,7 +171,7 @@ The following fields may be set through this Sample Request:
 
 
 
-## Delete Webhook Subscription
+### Delete Webhook Subscription
 > Sample Request:  
 
 ```http
@@ -196,7 +196,7 @@ This request deletes a webhook subscription, identified by its `subscription_id`
 
 
 
-## Trigger a Webhook Subscription
+### Trigger a Webhook Subscription
 > Sample Request:  
 
 ```http
@@ -219,7 +219,7 @@ This request manually triggers a given subscription, identified by its `subscrip
 |:-|:-|:-|
 | **object_id** | unsigned | The unique identifier of the object, of type `trigger_table`, to trigger the subscriptions. |
 
-### Handling the Response
+#### Handling the Response
 This request returns nothing to the user.
 
 
@@ -228,7 +228,7 @@ This request returns nothing to the user.
 
 
 
-## Dispatch a Webhook Subscription
+### Dispatch a Webhook Subscription
 > Sample Request:  
 
 ```http
@@ -251,7 +251,7 @@ This request manually dispatches a given subscription, identified by its `subscr
 |:-|:-|:-|
 | **object_id** | unsigned | The unique identifier of the object, of type `trigger_table` to run the dispatch on. |
 
-### Handling the Response
+#### Handling the Response
 The response will contain a single field:
 
 | Field | Type | Description |

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -15,6 +15,7 @@ includes:
   - introduction
   - configuring_responses
   - authentication
+  - endpoints
   - endpoints/activities
   - endpoints/addresses
   - endpoints/affiliations

--- a/source/javascripts/all_nosearch.js
+++ b/source/javascripts/all_nosearch.js
@@ -3,7 +3,7 @@
 //= require ./app/_lang
 
 $(function() {
-  loadToc($('#toc'), '.toc-link', '.toc-list-h2', 10);
+  loadToc($('#toc'), '.toc-link', '.toc-list-h2, .toc-list-h3', 10);
   setupLanguages($('body').data('languages'));
   $('.content').imagesLoaded( function() {
     window.recacheHeights();

--- a/source/javascripts/app/_search.js
+++ b/source/javascripts/app/_search.js
@@ -20,9 +20,10 @@
   $(bind);
 
   function populate() {
-    $('h1, h2').each(function() {
+    var indexSelector = 'h1, h2, h3';
+    $(indexSelector).each(function() {
       var title = $(this);
-      var body = title.nextUntil('h1, h2');
+      var body = title.nextUntil(indexSelector);
       index.add({
         id: title.prop('id'),
         title: title.text(),

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -87,6 +87,15 @@ under the License.
                   <li>
                     <a href="#<%= h2[:id] %>" class="toc-h2 toc-link" data-title="<%= h2[:content] %>"><%= h2[:content] %></a>
                   </li>
+                  <% if h2[:children].length > 0 %>
+                    <ul class="toc-list-h3">
+                      <% h2[:children].each do |h3| %>
+                        <li>
+                          <a href="#<%= h3[:id] %>" class="toc-h3 toc-link" data-title="<%= h1[:content] %>"><%= h3[:content] %></a>
+                        </li>
+                      <% end %>
+                    </ul>
+                  <% end %>
                 <% end %>
               </ul>
             <% end %>

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -59,7 +59,7 @@ html, body {
   bottom: 0;
   width: $nav-width;
   background-color: $nav-bg;
-  font-size: 14px;
+  font-size: 16px;
   font-weight: normal;
 
   // language selector for mobile devices
@@ -177,10 +177,20 @@ html, body {
     background-color: $nav-subitem-bg;
     font-weight: 500;
   }
+  
+  .toc-list-h3 {
+    display: none;
+    background-color: $nav-subitem-bg;
+  }
+
+  .toc-h3 {
+    padding-left: $nav-padding + $nav-padding + $nav-indent;
+    font-size: 14px;
+  }
 
   .toc-h2 {
     padding-left: $nav-padding + $nav-indent;
-    font-size: 13px;
+    font-size: 15px;
     line-height: 2.3;
   }
 
@@ -350,7 +360,7 @@ html, body {
   }
 
   // the div is the tocify hidden div for placeholding stuff
-  &>h1, &>h2, &>div {
+  &>h1, &>h2, &>h3, &>div {
     clear:both;
   }
 


### PR DESCRIPTION
Currently the top level doesn't accurately illustrate the hierarchy of the pages. This moves endpoints under the "Endpoints" layer and slightly increased font size while exposing the next tier of items.

~This should hold off for confirmation on searching h3 titles.~

![screen shot 2017-12-14 at 7 28 18 pm](https://user-images.githubusercontent.com/1269283/33982612-3c70db7a-e105-11e7-9a02-fdef85b8d529.png)
