### PR TITLE
Improvment: Edit resource, profile, and extension sections to avoid title duplication

### DIFF
--- a/source/includes/_changelog.md
+++ b/source/includes/_changelog.md
@@ -4,6 +4,12 @@ With the release of the new and easier to maintain documentation, we're going to
 
 **Note - Beta Changes:** New objects or endpoints may be introduced with a **(Beta)** tag, which may last up to a month after introduction. While in beta these are subject to change without notice.
 
+### Tuesday 16th January 2018
+
+#### Misc
+
+Rename some sections for clarity and to avoid title duplication.
+
 ### Monday 15th January 2018
 
 #### Deprecations

--- a/source/includes/endpoints/_affiliations.md
+++ b/source/includes/endpoints/_affiliations.md
@@ -418,7 +418,7 @@ This request will delete the affiliation identified by its `affiliation_id`. Thi
 
 
 
-### List Profile Field Values
+### List an Affiliation's Profile Field Values
 > See the [profiles section](#retrieve-a-list-of-profile-values) for a sample request
 
 `GET /affiliations/{affiliation_id}/profiles/values`
@@ -430,7 +430,7 @@ This request returns a list of [profile field values](#the-profile-value-object)
 
 
 
-### List Profile Fields
+### List Affiliation Profile Fields
 > See the [profiles section](#retrieve-a-list-of-profile-fields) for a sample request  
 
 `GET /affiliations/profiles/fields`
@@ -443,7 +443,7 @@ This request returns a list of [profile fields](#the-profile-field-object) avail
 
 
 
-### Update a Profile Field Value
+### Update a Profile Field Value on an Affiliation
 > See the [profiles section](#update-a-profile-value-link) for a sample request  
 
 `PUT /affiliations/{affiliation_id}/profiles/values/{profile_value_id}`
@@ -458,7 +458,7 @@ This request updates and returns a [profile field value](#the-profile-value-obje
 
 
 
-### Set a Profile Field Value
+### Set a Profile Field Value on an Affiliation
 > See the [profiles section](#create-a-profile-value-link) for a sample request
 
 `POST /affiliations/{affiliation_id}/profiles/fields/{profile_field_id}`
@@ -473,7 +473,7 @@ This request sets and returns a [profile value](#the-profile-value-object) for a
 
 
 
-### List Available Progressions
+### List Available Progressions on an Affiliation
 > See the [progressions section](#retrieve-a-list-of-available-progressions) for a sample request
 
 `GET /affiliations/{affiliation_id}/progressions`
@@ -486,7 +486,7 @@ This request returns a list of available [progressions](#progressions) for an [a
 
 
 
-### Auto Run a Progression
+### Auto Run a Progression on an Affiliation
 > See the [progressions section](#run-a-status-update-using-a-given-progression) for a sample request
 
 `[PUT | POST] /affiliations/{affiliation_id}/progressions/{progression_id}/auto`

--- a/source/includes/endpoints/_assets.md
+++ b/source/includes/endpoints/_assets.md
@@ -570,7 +570,7 @@ The response will be the single, updated [asset](#the-asset-object) with its def
 
 
 
-### List Extension Fields
+### List Asset Extension Fields
 > See the [extension section](#retrieve-a-list-of-extension-fields) for an example    
 
 `GET /assets/extensions/fields`
@@ -583,7 +583,7 @@ This request returns a list of [extension fields](#the-extension-field-object) a
 
 
 
-### List Extension Field Values
+### List an Asset's Extension Field Values
 > See the [extension section](#retrieve-a-list-of-extension-field-values) for an example     
 
 `GET /assets/{asset_id}/extensions/values`
@@ -596,7 +596,7 @@ This request returns a list of [extension values](#the-extension-value-object) f
 
 
 
-### Update an Extension Field Value
+### Update an Extension Field Value on an Asset
 > See the [extension section](#update-an-extension-value) for an example     
 
 `PUT /assets/{asset_id}/extensions/values/{extension_value_id}`
@@ -609,7 +609,7 @@ This request updates the value of an [extension field value](#the-extension-valu
 
 
 
-### Set an Extension Field Value
+### Set an Extension Field Value on an Asset
 > See the [extension section](#create-an-extension-value) for an example
 
 `POST /assets/{asset_id}/extensions/fields/{extension_field_id}`

--- a/source/includes/endpoints/_companies.md
+++ b/source/includes/endpoints/_companies.md
@@ -402,7 +402,7 @@ The response will be a single [contact](#contact) with its default fields and an
 
 
 
-### List Contacts
+### List Contacts Against a Company
 > Sample Request:  
 
 ```http
@@ -431,7 +431,7 @@ This request may be configured and handled as per [`GET /contacts`](#list-contac
 
 
 
-### Count Contacts
+### Count Contacts on a Company
 > Sample Request:  
 
 ```http
@@ -844,7 +844,7 @@ This request uses the given [progression](#progressions), specified by its `prog
 
 
 
-### List Addresses
+### List Addresses against a Company
 > Sample Request:  
 
 `GET /companies/{company_id}/addresses`
@@ -857,7 +857,7 @@ This request returns a list of [addresses](#addresses) associated with a [compan
 
 
 
-### Create an Address
+### Create an Address against a Company
 > Sample Request:
 
 `POST /companies/{company_id}/addresses`

--- a/source/includes/endpoints/_companies.md
+++ b/source/includes/endpoints/_companies.md
@@ -764,7 +764,7 @@ This response returns a list of manager (staff members) for the given company.
 
 
 
-### List Profile Field Values
+### List a Company's Profile Field Values
 > See the [profiles section](#retrieve-a-list-of-profile-values) for a sample request
 
 `GET /companies/{company_id}/profiles/values`
@@ -777,48 +777,8 @@ This request returns a list of [profile field values](#the-profile-value-object)
 
 
 
-### Update the value of a Profile Field
-> See the [profiles section](#update-a-profile-value-link) for a sample request  
-
-`PUT /companies/{company_id}/profiles/values/{profile_value_id}`
-
-This request updates and returns a [profile field value](#the-profile-value-object), specified by its `profile_value_id` of a particular [company](#the-company-object), identified by its `company_id`. This is the request [`PUT /{object}/{object_id}/profiles/values/{profile_value_id}`](#update-a-profile-value-link) where the object is "company", and whose id is `{company_id}`.
-
-
-
-
-
-
-
-### List Available Progressions
-> See the [progressions section](#retrieve-a-list-of-available-progressions) for a sample request  
-
-`GET /companies/{company_id}/progressions`
-
-This request returns a list of available [progressions](#progressions) for a [company](#the-company-object) identified by its `company_id`. This is the request [`GET /{object}/{object_id}/progressions`](#retrieve-a-list-of-available-progressions) where the object is "companies" whose id is `{company_id}`
-
-
-
-
-
-
-
-### Auto Run a Progression
-> See the [progressions section](#run-a-status-update-using-a-given-progression) for a sample request  
-
-`[PUT|POST] /companies/{company_id}/progressions/{progression_id}/auto`
-
-
-This request uses the given [progression](#progressions), specified by its `progression_id` to progress the status of a[company](#the-company-object), specified by its `company_id`. This is the request [`[PUT|POST] /{object}/{object_id}/progressions/{progression_id/auto}`](#run-a-status-update-using-a-given-progression) where the object is "companies" whose id is `{company_id}`.
-
-
-
-
-
-
-
-### List Profile Fields
-> See the [profiles section](#retrieve-a-list-of-profile-fields) for a sample request  
+### List Company Profile Fields
+> See the [profiles section](#retrieve-a-list-of-profile-fields) for a sample request
 
 `GET /companies/profiles/fields`
 
@@ -830,12 +790,53 @@ This request returns a list of [profile fields](#the-profile-field-object) avail
 
 
 
-### Create a Profile Field Value
+### Update a Profile Field Value on a Company
+> See the [profiles section](#update-a-profile-value-link) for a sample request
+
+`PUT /companies/{company_id}/profiles/values/{profile_value_id}`
+
+This request updates and returns a [profile field value](#the-profile-value-object), specified by its `profile_value_id` of a particular [company](#the-company-object), identified by its `company_id`. This is the request [`PUT /{object}/{object_id}/profiles/values/{profile_value_id}`](#update-a-profile-value-link) where the object is "company", and whose id is `{company_id}`.
+
+
+
+
+
+
+
+### Set a Profile Field Value on a Company
 > See the [profiles section](#create-a-profile-value-link) for a sample request
 
 `POST /companies/{company_id}/profiles/{profile_field_id}`
 
 This request sets and returns a [profile value](#the-profile-value-object) for a [profile field](#the-profile-field-object), specified by its `profile_field_id`, for a [company](#the-company-object), specified by its `company_id`. This is the request [`POST /{object}/{object_id}/profiles/fields/{profile_field_id}`](#update-a-profile-value-link) where is object is "companies" and whose id is `{company_id}`
+
+
+
+
+
+
+
+### List Available Progressions on a Company
+> See the [progressions section](#retrieve-a-list-of-available-progressions) for a sample request
+
+`GET /companies/{company_id}/progressions`
+
+This request returns a list of available [progressions](#progressions) for a [company](#the-company-object) identified by its `company_id`. This is the request [`GET /{object}/{object_id}/progressions`](#retrieve-a-list-of-available-progressions) where the object is "companies" whose id is `{company_id}`
+
+
+
+
+
+
+
+### Auto Run a Progression on a Company
+> See the [progressions section](#run-a-status-update-using-a-given-progression) for a sample request
+
+`[PUT|POST] /companies/{company_id}/progressions/{progression_id}/auto`
+
+
+This request uses the given [progression](#progressions), specified by its `progression_id` to progress the status of a [company](#the-company-object), specified by its `company_id`. This is the request [`[PUT|POST] /{object}/{object_id}/progressions/{progression_id/auto}`](#run-a-status-update-using-a-given-progression) where the object is "companies" whose id is `{company_id}`.
+
 
 
 
@@ -869,8 +870,8 @@ This request creates a [address](#addresses) against a [company](#the-company-ob
 
 
 
-### List Resource Collections
-> See the [resources (attachments) section](#retrieve-an-array-of-collections-for-an-object) for an example  
+### List a Company's Resource Collections
+> See the [resources (attachments) section](#retrieve-an-array-of-collections-for-an-object) for an example
 
 `GET /companies/{company_id}/collections`
 
@@ -882,8 +883,8 @@ This request returns a list of [collections](#resources) against a [company](#th
 
 
 
-### Upload a Resource (Attachment)
-> See the [resources (attachments) section](#upload-a-resource-to-a-collection-of-an-object) for an example  
+### Upload a Resource (Attachment) to a Collection on a Company
+> See the [resources (attachments) section](#upload-a-resource-to-a-collection-of-an-object) for an example
 
 `POST /companies/{company_id}/collections/{collection_id}/resources`
 

--- a/source/includes/endpoints/_contacts.md
+++ b/source/includes/endpoints/_contacts.md
@@ -369,7 +369,7 @@ This request sets a contact on the Accelo deployment, identified by it's `contac
 
 
 
-### List Addresses
+### List Addresses Against a Contact
 > Sample Request:  
 
 ```http

--- a/source/includes/endpoints/_contacts.md
+++ b/source/includes/endpoints/_contacts.md
@@ -425,7 +425,7 @@ This request returns a single status with its default fields and any additional 
 
 
 
-### List Segmentations
+### List Contact Segmentations
 > Sample Request:  
 
 `GET /contacts/{contact_id}/segmentations`
@@ -437,7 +437,7 @@ This request returns a list of [segmentations](#the-segmentation-object) for a [
 
 
 
-### List Profile Values
+### List a Contact's Profile Field Values
 > See the [profiles section](#retrieve-a-list-of-profile-values) for a sample request
 
 `GET /contacts/{contact_id}/profiles/values`
@@ -450,59 +450,33 @@ This request returns a list of [profile values](#the-profile-value-object) of a 
 
 
 
-### Update a Profile Field Value
-> See the [profiles section](#update-a-profile-value-link) for a sample request  
+### List Contact Profile Fields
+> See the [profiles section](#retrieve-a-list-of-profile-fields) for general usage.
+
+`GET /contacts/profiles/fields/`
+
+This request returns a list of [profile fields](#the-profile-field-object)
+available for [contacts](#the-contact-object).
+
+
+
+
+
+
+### Update a Profile Field Value on a Contact
+> See the [profiles section](#update-a-profile-value-link) for general usage.
 
 `PUT /contacts/{contact_id}/profiles/values/{profile_value_id}`
 
-This request updates and returns a [profile value](#the-profile-value-object), specified by its `profile_value_id`, of a particular [contact](#the-contact-object), specified by its `contact_id`. This is the request [`PUT /{object}/{object_id}/profiles/values/{profile_value_id}`](#update-a-profile-value-link) where the object is "contacts", and whose id is the `contact_id`.
+This request updates and returns a [profile value](#the-profile-value-object),
+specified by its `profile_value_id`, of a particular contact, specified by its
+`contact_id`.
 
 
 
 
 
-
-
-### List Available Progressions
-> See the [progressions section](#retrieve-a-list-of-available-progressions) for a sample request
-
-`GET /contacts/{contact_id}/progressions`
-
-This request returns a list of available [progressions](#the-progression-object) for a [contact](#the-contact-object), specified by its `contact_id`. This is the request [`GET /{object}/{object_id}/progressions`](#retrieve-a-list-of-available-progressions) where the object is "contacts" whose id is `contact_id`.
-
-
-
-
-
-
-
-### Auto Run a Progression
-> See the [progressions section](#run-a-status-update-using-a-given-progression) for a sample request
-
-`PUT|POST /contacts/{contact_id}/progressions/{progression_id}/auto`
-
-This request uses the given progression, specified by its `progression_id` to progress a [contact](#the-contact-object), specified by its `contact_id`. This is the request [`[POST|PUT] /{object}/{object_id}/progressions/{progression_id}/auto`](#run-a-status-update-using-a-given-progression) where the object is "contact" whose id is `contact_id`.
-
-
-
-
-
-
-
-### List Profile Fields
-> See the [profiles section](#retrieve-a-list-of-profile-fields) for a sample request  
-
-`GET /contacts/profiles/fields`
-
-This request returns a list of [profile fields](#the-profile-field-object) available for [contacts](#the-contact-object). This is the request [`GET /{object}/profiles/fields`](#retrieve-a-list-of-profile-fields) where the object is "contacts".
-
-
-
-
-
-
-
-### Create a Profile Field Value
+### Set a Contact's Profile Field Value
 > See the [profiles section](#create-a-profile-value-link) for a sample request
 
 `POST /contacts/{contact_id}/profiles/fields/{profile_field_id}`
@@ -515,7 +489,33 @@ This request sets and returns a [profile value](#the-profile-value-object) for a
 
 
 
-### List Resource Collections
+### List Available Progressions on a Contact
+> See the [progressions section](#retrieve-a-list-of-available-progressions) for a sample request
+
+`GET /contacts/{contact_id}/progressions`
+
+This request returns a list of available [progressions](#the-progression-object) for a [contact](#the-contact-object), specified by its `contact_id`. This is the request [`GET /{object}/{object_id}/progressions`](#retrieve-a-list-of-available-progressions) where the object is "contacts" whose id is `contact_id`.
+
+
+
+
+
+
+
+### Auto Run a Progression on a Contact
+> See the [progressions section](#run-a-status-update-using-a-given-progression) for a sample request
+
+`PUT|POST /contacts/{contact_id}/progressions/{progression_id}/auto`
+
+This request uses the given progression, specified by its `progression_id` to progress a [contact](#the-contact-object), specified by its `contact_id`. This is the request [`[POST|PUT] /{object}/{object_id}/progressions/{progression_id}/auto`](#run-a-status-update-using-a-given-progression) where the object is "contact" whose id is `contact_id`.
+
+
+
+
+
+
+
+### List a Contact's Resource Collections
 > See the [resources (attachments) section](#retrieve-an-array-of-collections-for-an-object) for an example
 
 `GET /contacts/{contact_id}/collections`
@@ -528,7 +528,7 @@ This request returns a list of [collections](#resources-attachments) against a [
 
 
 
-### Upload a Resource (Attachment)
+### Upload a Resource (Attachment) to a Collection on a Contact
 > See the [resources (attachments) section](#upload-a-resource-to-a-collection-of-an-object) for an example  
 
 `POST /contacts/{contact_id}/collections/{collection_id}/resources`

--- a/source/includes/endpoints/_contracts.md
+++ b/source/includes/endpoints/_contracts.md
@@ -617,7 +617,7 @@ This request reopens and returns a previously close [contract period](#the-contr
 
 
 
-### List Available Progressions
+### List Available Progressions on a Contract
 > See the [progressions section](#retrieve-a-list-of-available-progressions) for a sample request
 
 `GET /contracts/{contract_id}/progressions`
@@ -629,7 +629,7 @@ This request returns a list of available [progressions](#the-progression-object)
 
 
 
-### Auto Run a Progression
+### Auto Run a Progression on a Contract
 > See the [progressions section](#run-a-status-update-using-a-given-progression) for a sample request
 
 `[POST|PUT] /contracts/{contract_id}/progressions/{progression_id}/auto`
@@ -641,7 +641,7 @@ This request uses the given progression, specified by its `progression_id` to pr
 
 
 
-### List Resource Collections
+### List a Contract's Resource Collections
 > See the [resources (attachments) section](#retrieve-an-array-of-collections-for-an-object) for an example  
 
 `GET /companies/{company_id}/collections`
@@ -653,7 +653,7 @@ This request returns a list of [collections](#resources) against a [company](#th
 
 
 
-### Upload a Resource (Attachment)
+### Upload a Resource (Attachment) to a Collection on a Contract
 > See the [resources (attachments) section](#upload-a-resource-to-a-collection-of-an-object) for an example   
 
 `POST /companies/{company_id}/collections/{collection_id}/resources`
@@ -665,7 +665,7 @@ This request uploads a [resource](#resources) to a collection, specified by its 
 
 
 
-### List Extension Fields
+### List Contract Extension Fields
 > See the [extension section](#retrieve-a-list-of-extension-fields) for an example
 
 `GET /contracts/extensions/fields`
@@ -677,7 +677,7 @@ This request returns a list of [extension fields](#the-extension-field-object) a
 
 
 
-### List Extension Field Values
+### List a Contract's Extension Field Values
 > See the [extension section](#retrieve-a-list-of-extension-field-values) for an example     
 
 `GET /contracts/{contract_id}/extensions/values`
@@ -689,7 +689,7 @@ This request returns a list of [extension values](#the-extension-value-object) f
 
 
 
-### Update an Extension Field Value
+### Update an Extension Field Value on a Contract
 > See the [extension section](#update-an-extension-value) for an example    
 
 `PUT /contracts/{contract_id}/extensions/values/{extension_value_id}`
@@ -700,7 +700,7 @@ This request updates the value of an [extension field value](#the-extension-valu
 
 
 
-### Set an Extension Value
+### Set an Extension Value on a Contract
 > See the [extension section](#create-an-extension-value) for an example  
 
 `POST /contracts/{contract_id}/extensions/fields/{extension_field_id}`

--- a/source/includes/endpoints/_expenses.md
+++ b/source/includes/endpoints/_expenses.md
@@ -509,7 +509,7 @@ This request removes an expense from the deployment. It takes no parameters and 
 
 
 
-### List Available Progressions
+### List Available Progressions on an Expense
 > See the [progressions section](#retrieve-a-list-of-available-progressions) for a sample request
 
 `GET /companies/{expense_id}/progressions`
@@ -521,7 +521,7 @@ This request returns a list of available [progressions](#progressions) for an [e
 
 
 
-### Auto Run a Progression
+### Auto Run a Progression on an Expense
 > See the [progressions section](#run-a-status-update-using-a-given-progression) for a sample request
 
 `[PUT|POST] /companies/{expense_id}/progressions/{progression_id}/auto`

--- a/source/includes/endpoints/_issues.md
+++ b/source/includes/endpoints/_issues.md
@@ -785,7 +785,7 @@ Returns the number of issue priorities.
 
 
 
-### List Profile Fields
+### List Issue Profile Fields
 > See the [profiles section](#retrieve-a-list-of-profile-fields) for a sample request  
 
 `GET /issues/profiles/fields`
@@ -798,7 +798,7 @@ This request returns a list of [profile fields](#the-profile-field-object) avail
 
 
 
-### List Profile Field Values
+### List an Issue's Profile Field Values
 > See the [profiles section](#retrieve-a-list-of-profile-values) for a sample request
 
 `GET /issues/{issue_id}/profiles/values`
@@ -811,10 +811,10 @@ This request returns a list of [profile values](#the-profile-value-object) of an
 
 
 
-### Update a Profile Value
+### Update a Profile Value on an Issue
 > See the [profiles section](#update-a-profile-value-link) for a sample request  
 
-`PUT /issues/issue_id/profiles/values/{profile_value_id}`
+`PUT /issues/{issue_id}/profiles/values/{profile_value_id}`
 
 This request updates and returns a [profile value](#the-profile-value-object), specified by its `profile_value_id`, of a particular issue,specified by its `issue_id`. This is the request [`PUT /{object}/{object_id}/profiles/values/{profile_value_id}`](#update-a-profile-value-link) where the object is "issues", and whose id is the `{issue_id}`.
 
@@ -824,7 +824,7 @@ This request updates and returns a [profile value](#the-profile-value-object), s
 
 
 
-### Set a Profile Value
+### Set a Profile Value on an Issue
 > See the [profiles section](#create-a-profile-value-link) for a sample request
 
 `POST /issues/{issue_id}/profiles/fields/{profile_field_id}`
@@ -837,7 +837,7 @@ This request sets and returns a [profile value](#the-profile-value-object) for a
 
 
 
-### List Extension Fields
+### List Issue Extension Fields
 > See the [extension section](#retrieve-a-list-of-extension-fields) for an example  
 
 `GET /issues/extensions/fields`
@@ -850,7 +850,7 @@ This request returns a list of [extension fields](#the-extension-field-object) a
 
 
 
-### List Extension Field Values
+### List an Issue's Extension Field Values
 > See the [extension section](#retrieve-a-list-of-extension-field-values) for an example    
 
 `GET /issues/{issue_id}/extensions/values`
@@ -863,7 +863,7 @@ This request returns a list of [extension values](#the-extension-value-object) f
 
 
 
-### Update an Extension Field Value
+### Update an Extension Field Value on an Issue
 > See the [extension section](#update-an-extension-value) for an example      
 
 `PUT /issues/{issue_id}/extensions/values/{extension_value_id}`
@@ -876,7 +876,7 @@ This request updates the value of an [extension field value](#the-extension-valu
 
 
 
-### Set an Extension Field Value
+### Set an Extension Field Value on an Issue
 > Sample Request:  
 
 `POST /issues/{issue_id}/extensions/fields/{extension_field_id}`
@@ -890,7 +890,7 @@ This request sets and returns the value of an extension field, specified by its 
 
 
 
-### List Available Progressions
+### List Available Progressions on an Issue
 > See the [progressions section](#retrieve-a-list-of-available-progressions) for a sample request  
 
 `GET /issues/{issue_id}/progressions`
@@ -903,7 +903,7 @@ This request returns a list of available [progressions](#the-progression-object)
 
 
 
-### Auto Run a Progression
+### Auto Run a Progression on an Issue
 > See the [progressions section](#run-a-status-update-using-a-given-progression) for a sample request  
 
 `[POST|PUT] /issues/{issue_id}/progressions/{progression_id}/auto`
@@ -916,7 +916,7 @@ This request uses the given progression, specified by its `progression_id` to pr
 
 
 
-### List Resource Collections
+### List an Issue's Resource Collections
 > See the [resources (attachments) section](#retrieve-an-array-of-collections-for-an-object) for an example  
 
 `GET /issues/{issue_id}/collections`
@@ -929,7 +929,7 @@ This request returns a list of [resource collections](#resources-attachments) ag
 
 
 
-### Upload a Resource (Attachment)
+### Upload a Resource (Attachment) to a Collection on an Issue
 > See the [resources (attachments) section](#upload-a-resource-to-a-collection-of-an-object) for an example   
 
 `POST /issues/{issue_id}/collections/{collection_id}/resources`

--- a/source/includes/endpoints/_jobs.md
+++ b/source/includes/endpoints/_jobs.md
@@ -669,7 +669,7 @@ This request deletes a job from the deployment, specified by its `job_id`. This 
 
 
 
-### List Extension Fields
+### List Job Extension Fields
 > See the [extension section](#retrieve-a-list-of-extension-fields) for an example
 
 `GET /jobs/extensions/fields`
@@ -682,7 +682,7 @@ This request returns a list of [extension fields](#the-extension-field-object) a
 
 
 
-### List Extension Field Values
+### List a Job's Extension Field Values
 > See the [extension section](#retrieve-a-list-of-extension-field-values) for an example    
 
 `GET /jobs/{job_id}/extensions/values`
@@ -695,7 +695,7 @@ This request returns a list of [extension values](#the-extension-value-object) f
 
 
 
-### Update an Extension Field Value
+### Update an Extension Field Value on a Job
 > See the [extension section](#update-an-extension-value) for an example     
 
 `PUT /jobs/{job_id}/extensions/values/{extension_value_id}`
@@ -708,7 +708,7 @@ This request updates the value of an [extension field value](#the-extension-valu
 
 
 
-### Set an Extension Field Value
+### Set an Extension Field Value on a Job
 > Sample Request:  
 
 `POST /jobs/{job_id}/extensions/fields/{extension_field_id}`
@@ -722,7 +722,7 @@ This request sets and returns the value of an extension field, specified by its 
 
 
 
-### List Available Progressions
+### List Available Progressions on a Job
 > See the [progressions section](#retrieve-a-list-of-available-progressions) for a sample request
 
 `GET /jobs/{jobs_id}/progressions`
@@ -735,7 +735,7 @@ This request returns a list of available [progressions](#the-progression-object)
 
 
 
-### Auto Run Progression
+### Auto Run Progression on a Job
 > See the [progressions section](#run-a-status-update-using-a-given-progression) for a sample request
 
 `[POST|PUT] /jobs/{jobs_id}/progressions/{progression_id}/auto`
@@ -748,7 +748,7 @@ This request uses the given progression, specified by its `progression_id` to pr
 
 
 
-### List Resource Collections
+### List a Job's Resource Collections
 > See the [resources (attachments) section](#retrieve-an-array-of-collections-for-an-object) for an example
 
 `GET /jobs/{job_id}/collections`
@@ -761,7 +761,7 @@ This request returns a list of [resource collections](#resources-attachments) ag
 
 
 
-### Upload a resource (Attachment)
+### Upload a Resource (Attachment) to a Collection on a Job
 > See the [resources (attachments) section](#upload-a-resource-to-a-collection-of-an-object) for an example   
 
 `POST jobs/{job_id}/collections/{collection_id}/resources`

--- a/source/includes/endpoints/_milestones.md
+++ b/source/includes/endpoints/_milestones.md
@@ -206,7 +206,7 @@ This request will return a count of milestones in a list defined by any availabl
 
 
 
-### List Profile Fields
+### List Milestone Profile Fields
 > See the [profiles section](#retrieve-a-list-of-profile-fields)) for a sample request
 
 `GET /milestones/profiles/fields`
@@ -219,7 +219,7 @@ This request returns a list of [profile fields](#the-profile-field-object) avail
 
 
 
-### List Profile Field Values
+### List a Milestone's Profile Field Values
 > See the [profiles section](#retrieve-a-list-of-profile-values) for a sample request  
 
 `GET /milestones/{milestone_id}/profiles/values`
@@ -232,7 +232,7 @@ This request returns a list of [profile values](#the-profile-value-object) of a 
 
 
 
-### Update a Profile Field Value
+### Update a Profile Field Value on a Milestone
 > See the [profiles section](#update-a-profile-value-link) for a sample request   
 
 `PUT /milestones/{milestone_id}/profiles/values/{profile_value_id}`
@@ -245,7 +245,7 @@ This request updates and returns a [profile value](#the-profile-value-object), s
 
 
 
-### Set a Profile Field Value
+### Set a Profile Field Value on a Milestone
 > See the [profiles section](#create-a-profile-value-link) for a sample request
 
 `POST /milestones/{milestone_id}/profiles/fields/{profile_field_id}`
@@ -258,7 +258,7 @@ This request sets and returns a [profile value](#the-profile-value-object) for a
 
 
 
-### List Available Progressions
+### List Available Progressions on a Milestone
 > See the [progressions section](#retrieve-a-list-of-available-progressions) for a sample request
 
 `GET /milestones/{milestone_id}/progressions`
@@ -271,7 +271,7 @@ This request returns a list of available [progressions](#the-progression-object)
 
 
 
-### Auto Run a Progression
+### Auto Run a Progression on a Milestone
 > See the [progressions section](#run-a-status-update-using-a-given-progression) for a sample request
 
 `PUT|POST /milestones/{milestone_id}/progressions/{progression_id}/auto`

--- a/source/includes/endpoints/_prospects.md
+++ b/source/includes/endpoints/_prospects.md
@@ -470,7 +470,7 @@ The response will be the single, updated [prospect object](#the-prospect-object)
 
 
 
-### List Profile Fields
+### List Prospect Profile Fields
 > See the [profiles section](#retrieve-a-list-of-profile-fields for a sample request
 
 `GET /prospects/profiles/fields`
@@ -483,7 +483,7 @@ This request returns a list of [profile fields](#the-profile-field-object) avail
 
 
 
-### List Profile Field Values
+### List a Prospect's Profile Field Values
 > See the [profiles section](#retrieve-a-list-of-profile-values) for a sample request  
 
 `GET /prospects/{prospect_id}/profiles/values`
@@ -496,7 +496,7 @@ This request returns a list of [profile values](#the-profile-value-object) of a 
 
 
 
-### Update a Profile Field Value
+### Update a Profile Field Value on a Prospect
 > See the [profiles section](#update-a-profile-value-link) for a sample request  
 
 `PUT /prospects/{prospect_id}/profiles/values/{profile_value_id}`
@@ -510,7 +510,7 @@ This request updates and returns a [profile value](#the-profile-value-object), s
 
 
 
-### Set a Profile Field Value
+### Set a Profile Field Value on a Prospect
 > See the [profiles section](#create-a-profile-value-link) for a sample request
 
 `PUT|POST /prospects/{prospect_id}/profiles/fields/{profile_field_id}`
@@ -523,7 +523,7 @@ This request sets and returns a [profile value](#the-profile-value-object) for a
 
 
 
-### List Extension Fields
+### List Prospect Extension Fields
 > See the [extension section](#retrieve-a-list-of-extension-fields) for an example   
 
 `GET /prospects/extensions/fields`
@@ -536,7 +536,7 @@ This request returns a list of [extension fields](#the-extension-field-object) a
 
 
 
-### List Extension Field Values
+### List a Prospect's Extension Field Values
 > See the [extension section](#retrieve-a-list-of-extension-field-values) for an example    
 
 `GET /prospects/{prospect_id}/extensions/values`
@@ -549,7 +549,7 @@ This request returns a list of [extension values](#the-extension-value-object) f
 
 
 
-### Update an Extension Field Value
+### Update an Extension Field Value on a Prospect
 > See the [extension section](#update-an-extension-value) for an example    
 
 `PUT /prospects/{prospect_id}/extensions/values/{extension_value_id}`
@@ -562,7 +562,7 @@ This request updates the value of an [extension field value](#the-extension-valu
 
 
 
-### Set an Extension Field Value
+### Set an Extension Field Value on a Prospect
 > Sample Request:  
 
 `POST /prospects/{prospect_id}/extensions/fields/{extension_field_id}`
@@ -575,7 +575,7 @@ This request sets and returns the value of an extension field, specified by its 
 
 
 
-### List Available Progressions
+### List Available Progressions on a Prospect
 > See the [progressions section](#retrieve-a-list-of-available-progressions) for a sample request
 
 `GET /prospects/{prospect_id}/progressions`
@@ -588,7 +588,7 @@ This request returns a list of available [progressions](#the-progression-object)
 
 
 
-### Auto Run a Progression
+### Auto Run a Progression on a Prospect
 > See the [progressions section](#run-a-status-update-using-a-given-progression) for a sample request
 
 `PUT|POST /prospects/{prospect_id}/progressions/{progression_id}/auto`
@@ -601,7 +601,7 @@ This request uses the given progression, specified by its `progression_id` to pr
 
 
 
-### Retrieve a List of Resource Collections for a Prospect
+### List a Prospect's Resource Collections
 > Sample Request:  
 
 `GET /prospects/{prospect_id}/collections`
@@ -614,7 +614,7 @@ This request returns a list of [resource collections](#resources-attachments) ag
 
 
 
-### Upload a Resource (Attachment) to a Collection of a Prospect
+### Upload a Resource (Attachment) to a Collection on a Prospect
 > Sample Request:  
 
 `POST /prospects/{prospect_id}/collections/{collection_id}/resources`

--- a/source/includes/endpoints/_staff.md
+++ b/source/includes/endpoints/_staff.md
@@ -288,7 +288,7 @@ This request removes a [staff member](#the-staff-object) from the deployment, id
 
 
 
-### List Profile Fields
+### List Staff Profile Fields
 > See the [profiles section](#retrieve-a-list-of-profile-fields) for a sample request  
 
 `GET /staff/profiles/fields`
@@ -301,7 +301,7 @@ This request returns a list of [profile fields](#the-profile-field-object) avail
 
 
 
-### List Profile Field Values
+### List a Staff's Profile Field Values
 > See the [profiles section](#retrieve-a-list-of-profile-values) for a sample request
 
 `GET /staff/{staff_id}/profiles/values`
@@ -314,7 +314,7 @@ This request returns a list of [profile values](#the-profile-value-object) of a 
 
 
 
-### Update a Profile Field Value
+### Update a Profile Field Value on a Staff
 > See the [profiles section](#update-a-profile-value-link) for a sample request  
 
 `PUT /staff/{staff_id}/profiles/fields/{profile_value_id}`
@@ -328,7 +328,7 @@ This request updates and returns a [profile value](#the-profile-value-object), s
 
 
 
-### Set a Profile Field Value
+### Set a Profile Field Value on a Staff
 > See the [profiles section](#create-a-profile-value-link) for a sample request 
 
 `PUT|POST /staff/{staff_id}/profiles/fields/{profile_field_id}`

--- a/source/includes/endpoints/_tasks.md
+++ b/source/includes/endpoints/_tasks.md
@@ -461,7 +461,7 @@ The response will be the single, created [task](#the-task-object) with its defau
 
 
 
-### List Available Progressions
+### List Available Progressions on a Task
 > See the [progressions section](#retrieve-a-list-of-available-progressions) for a sample request
 
 `GET /tasks/{task_id}/progressions`
@@ -474,7 +474,7 @@ This request returns a list of available [progressions](#the-progression-object)
 
 
 
-### Auto Run a Progression
+### Auto Run a Progression on a Task
 > See the [progressions section](#run-a-status-update-using-a-given-progression) for a sample request 
 
 `PUT|POST /tasks/{task_id}/progressions/{progression_id}/auto`
@@ -487,7 +487,7 @@ This request uses the given progression, specified by its `progression_id` to pr
 
 
 
-### Auto Progress to Start or End
+### Auto Progress a Task to Start or End
 > Requests:  
 
 `PUT|POST /tasks/{task_id}/progressions/start`  


### PR DESCRIPTION
Also do some rearranging within these sections for consistency

Nesting the endpoints has caused ambiguity in link naming. Previously https://api.accelo.com/docs/#list-profile-fields would take you to the "List Profile Fields" section under whatever object you were viewing, however, as all objects are now nested at the same level this linking is ambiguous (and seems to just send you to the first instance). The previous title system also just unnecessarily ambiguous.
