### PR TITLE
Update dependency nokogiri from 1.6.8.1 to 1.8.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,4 @@ gem 'middleman-autoprefixer', '~> 2.7.0'
 gem "middleman-sprockets", "~> 4.1.0"
 gem 'rouge', '~> 2.0.5'
 gem 'redcarpet', '~> 3.4.0'
-gem 'nokogiri', '~> 1.6.8'
+gem 'nokogiri', '~> 1.8.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,10 +79,10 @@ GEM
     middleman-syntax (3.0.0)
       middleman-core (>= 3.2)
       rouge (~> 2.0)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.1)
-    nokogiri (1.6.8.1)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
     padrino-helpers (0.13.3.3)
       i18n (~> 0.6, >= 0.6.7)
       padrino-support (= 0.13.3.3)
@@ -118,7 +118,7 @@ DEPENDENCIES
   middleman-autoprefixer (~> 2.7.0)
   middleman-sprockets (~> 4.1.0)
   middleman-syntax (~> 3.0.0)
-  nokogiri (~> 1.6.8)
+  nokogiri (~> 1.8.2)
   redcarpet (~> 3.4.0)
   rouge (~> 2.0.5)
 
@@ -126,4 +126,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.14.5
+   1.16.1


### PR DESCRIPTION
This is to address a vulnerability, for further details:
https://github.com/sparklemotion/nokogiri/issues/1673