### PR TITLE
Revert "Bump rack from 2.0.8 to 2.2.3"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
       activesupport (>= 3.1)
     parallel (1.10.0)
     public_suffix (2.0.5)
-    rack (2.2.3)
+    rack (2.0.8)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)


### PR DESCRIPTION
Reverts Accelo/docs#93, it caused an issue with the build and deploy. Will have to look into this.