### PR TITLE
Automatically Deploy Docs Via Github Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy
+
+on:
+  push:
+    branches: [ 'master' ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      ruby-version: 2.5
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ env.ruby-version }}
+
+    - uses: actions/cache@v2
+      with:
+        path: vendor/bundle
+        key: gems-${{ runner.os }}-${{ matrix.ruby-version }}-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          gems-${{ runner.os }}-${{ matrix.ruby-version }}-
+          gems-${{ runner.os }}-
+    - run: bundle config set deployment 'true'
+    - name: bundle install
+      run: |
+        bundle config path vendor/bundle
+        bundle install --jobs 4 --retry 3
+    - run: bundle exec middleman build
+
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./build
+        keep_files: true

--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ vagrant up
 
 You can now see the docs at http://localhost:4567.
 
+### Deploying
+
+The Accelo Public API Docs are now automatically deployed via a github action `.github/workflows/deploy.yml` which triggers
+when changes are applied to master.
+
+If you wish to manually deploy the documentation, it can be done via the `deploy.sh` script.
+
 ### Note on JavaScript Runtime
 
 For those who don't have JavaScript runtime or are experiencing JavaScript runtime issues with ExecJS, it is recommended to add the [rubyracer gem](https://github.com/cowboyd/therubyracer) to your gemfile and run `bundle` again.


### PR DESCRIPTION
Changes automatically deploy the documentation via github actions when changes are made to master. This follows the same pattern used for the official slate documentation.