### PR TITLE
Fixing 2 sections under Contracts, that were referring to Companies

### DIFF
--- a/source/includes/endpoints/_contracts.md
+++ b/source/includes/endpoints/_contracts.md
@@ -900,11 +900,11 @@ where the object is "contracts" whose id is `{contract_id}`.
 ### List a Contract's Resource Collections
 > See the [resources (attachments) section](#retrieve-an-array-of-collections-for-an-object) for an example  
 
-`GET /companies/{company_id}/collections`
+`GET /contracts/{contract_id}/collections`
 
-This request returns a list of [collections](#resources) against a [company](#the-company-object), specified by its
-`company_id`. This is the request [`GET /{object}/{object_id}/collections`](#retrieve-an-array-of-collections-for-an-object) 
-where the object is "companies" and whose id is `{company_id}`.
+This request returns a list of [collections](#resources) against a [contracts](#the-contract-object),
+specified by its `contract_id`. This is the request [`GET /{object}/{object_id}/collections`](#retrieve-an-array-of-collections-for-an-object) 
+where the object is "contracts" whose id is `{contract_id}`.
 
 
 
@@ -914,12 +914,12 @@ where the object is "companies" and whose id is `{company_id}`.
 ### Upload a Resource (Attachment) to a Collection on a Contract
 > See the [resources (attachments) section](#upload-a-resource-to-a-collection-of-an-object) for an example   
 
-`POST /companies/{company_id}/collections/{collection_id}/resources`
+`POST /contracts/{contract_id}/collections/{collection_id}/resources`
 
-This request uploads a [resource](#resources) to a collection, specified by its `collection_id`, of a [company](#the-
-company-object) specified by its `company_id`. This is the request 
+This request uploads a [resource](#resources) to a collection, specified by its `collection_id`, of a [contracts](#the-contract-object),
+specified by its `contract_id`. This is the request 
 [POST/{object}/{object_id}/collections/{collection_id}/resources](#upload-a-resource-to-a-collection-of-an-object) 
-where the object is "companies" and whose id is `{company_id}`.
+where the object is "contracts" whose id is `{contract_id}`.
 
 
 


### PR DESCRIPTION
The text and links under the `List a Contract's Resource Collections` and the `Upload a Resource (Attachment) to a Collection on a Contract` were referring to Companies, so have corrected the text to Contracts instead (I suspect a dodgy Cut and Paste at some point).