### PR TITLE
Always Deploy Changes Automatically

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,3 +40,4 @@ jobs:
         github_token: ${{ secrets.DEPLOY_DOCS }}
         publish_dir: ./build
         keep_files: true
+        allow_empty_commit: true


### PR DESCRIPTION
Adding this option should ensure that all changes are automatically deployed. This should mean changing the gemfile will ensure a re-deploy.

See: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-allow-empty-commits-allow_empty_commit for docs