### PR TITLE
FUSION-1214 Update doc for task priority

### DIFF
--- a/source/includes/endpoints/_tasks.md
+++ b/source/includes/endpoints/_tasks.md
@@ -555,6 +555,7 @@ The following fields from the [task object](#the-task-object) may be updated thr
 | assignee_id |
 | affiliation_id |
 | manager_id |
+| priority_id |
 | type_id |
 | rate_id |
 | rate_charged |
@@ -609,6 +610,7 @@ The following fields from the [task object](#the-task-object) may be set with th
 | assignee_id | The `staff_id` for the [staff](#staff) to be assigned to the task. |
 | affiliation_id | The `affiliation_id` for the [affiliation](#affiliations) to be associated with the task. |
 | date_due ||
+| priority_id | The [priority](#the-task-priority) object's id. For available priorities see [`GET /tasks/priorities`](#list-task-priorities) |
 | remaining | The field `budgeted` will be automatically updated with this value upon creation. |
 | rate_id | Only available if the task is against a "job" or "milestone". The `rate_id` of the [rate](#rates) for this task. |
 | rate_charged | Only available if the task is against a "job" or "milestone". The rate charged for work on this task, as a decimal. |


### PR DESCRIPTION
Update docs for task priority:

- Add task_priority to Task Object
<img width="864" alt="Screen Shot 2021-10-11 at 12 54 43 pm" src="https://user-images.githubusercontent.com/8143167/136740215-948670f6-dd71-48fb-a423-c5f82e2f6a08.png">

- Add The Task Priority section
<img width="862" alt="Screen Shot 2021-10-11 at 12 54 48 pm" src="https://user-images.githubusercontent.com/8143167/136740243-05132166-ce30-4af2-bed9-3f6b6b134d79.png">

- Add doc for List Task Priorities
<img width="866" alt="Screen Shot 2021-10-11 at 12 59 50 pm" src="https://user-images.githubusercontent.com/8143167/136740323-dc3d7e61-d4dd-44a8-ab5b-af70b48ff388.png">

- Add Order by task_priority
- Add priority_id to POST and PUT tasks


