### PR TITLE
Upgrade the GitHub Pages action in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,9 +35,9 @@ jobs:
     - run: bundle exec middleman build
 
     - name: Deploy
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
-        github_token: ${{ secrets.DEPLOY_DOCS }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./build
         keep_files: true
         allow_empty_commit: true


### PR DESCRIPTION
This change bumps the `peaceiris/actions-gh-pages` action to v4 and uses the automatically-generated `GITHUB_TOKEN` secret instead of the outdated `DEPLOY_DOCS` secret.

Ref. https://github.com/peaceiris/actions-gh-pages?tab=readme-ov-file#supported-tokens