### PR TITLE
Remove Verbiage of "issue_type" Being the Correct Filter in List Issues

### DIFF
--- a/source/includes/endpoints/_issues.md
+++ b/source/includes/endpoints/_issues.md
@@ -327,8 +327,7 @@ This request supports [basic filters](#filters-basic-filters) over the following
 | against_id ||
 | against_type ||
 | status | Filter by the `status_id` of the issue. |
-| type | Filter by the `type_id` of the issue. **Deprecated**, please use `issue_type`. |
-| issue_type | Filter by the `issue_type_id`. |
+| type | Filter by the `type_id` of the issue. |
 | affiliation | Filter by the `affiliation_id` of the issue. |
 | class | Filter by the `class_id` of the issue. |
 | priority | **Deprecated**, please use `issue_priority` |


### PR DESCRIPTION
In the current Accelo docs under List Issues and Basic Filtering, it incorrectly states to use "issue_type" for filtering by the "issue_type_id" - however, this filter does not work and leads developers to incorrect and frustrating results.

The "type" filter must be used. While "type" is listed as _deprecated_ in the actual object documentation, the docs should still be relevant and correct to what actually, currently functions. Postman example below.

First image, we see we attempt to use "issue_type" in the filter

<img width="846" height="760" alt="image" src="https://github.com/user-attachments/assets/c46e8793-3ab7-43bc-8f1f-9fd06b5269d4" />

However, we get results back that are not just of that issue_type_id.

In the second image, when using "type" we get the correct results.

<img width="828" height="562" alt="image" src="https://github.com/user-attachments/assets/6f2abd03-9ef7-459a-9a36-e8839e91cc09" />

Currently "issue_type" does not function as a valid or useful filter. This PR removes it from the List Issues docs and removes deprecation notice of "type" because there is currently **no other way** to filer by type.
