### PR TITLE
Docs - clarify _fields and _method=get usage

### DIFF
--- a/source/includes/_configuring_responses.md
+++ b/source/includes/_configuring_responses.md
@@ -131,18 +131,15 @@ For example if we wanted to find all activities that were NOT created against a 
 > Example request, filter activities by those owned by a staff member:
 
 ```http
-GET /activities HTTP/1.1
+GET /activities?_filters=owner_type(staff) HTTP/1.1
 HOST: {deployment}.api.accelo.com
 Authorization: Bearer {access_token}
-
-_filters=owner_type(staff)
 ```
 
 ```shell
 curl -X GET \
-	https://{deployment}.api.accelo.com/api/v0/activities \
-	-H 'authorization: Bearer {access_token}' \
-	-d '_filters=owner_type(staff)'
+	"https://{deployment}.api.accelo.com/api/v0/activities?_filters=owner_type(staff)" \
+	-H 'authorization: Bearer {access_token}'
 ```
 
 These simply filter resources with certain fields for certain values, generally they are requested simply by
@@ -161,18 +158,15 @@ fields, so for example if we wanted to search for activities owned by the staff 
 > Filter activities by those created after 2017-03-22 00:00:00 (UTC)
 
 ```http
-GET /activities HTTP/1.1
+GET /activities?_filters=date_created_after(1490140800) HTTP/1.1
 HOST: {deployment}.api.accelo.com
 Authorization: Bearer {access_token}
-
-_filters=date_created_after(1490140800)
 ```
 
 ```shell
 curl -X GET \
-	https://{deployment}.api.accelo.com/api/v0/activities \
-	-H 'authorization: Bearer {access_token}' \
-	-d '_filters=date_created_after(1490140800)'
+	"https://{deployment}.api.accelo.com/api/v0/activities?_filters=date_created_after(1490140800)" \
+	-H 'authorization: Bearer {access_token}'
 ```
 
 Many endpoints contain fields representing dates, such as `date_created` under [activities](#activities). Date fields
@@ -195,18 +189,15 @@ of these "date_fields" through the following filters:
 > Filter activities with and id greater than 17:
 
 ```http
-GET /activities HTTP/1.1
+GET /activities?_filters=id_greater_than(17) HTTP/1.1
 HOST: {deployment}.api.accelo.com
 Authorization: Bearer {access_token}
-
-_filters=id_greater_than(17)
 ```
 
 ```shell
 curl -X GET \
-	https://{deployment}.api.accelo.com/api/v0/activities \
-	-H 'authorization: Bearer {access_token}' \
-	-d '_filters=id_greater_than(17)'
+	"https://{deployment}.api.accelo.com/api/v0/activities?_filters=id_greater_than(17)" \
+	-H 'authorization: Bearer {access_token}'
 ```
 
 These are similar to [Date Filters](#filters-date-filters) except they operate on non-date fields. For a given "field"
@@ -231,18 +222,15 @@ there are four range filters defined:
 > Filter activities by descending order of id:
 
 ```http
-GET /activities HTTP/1.1
+GET /activities?_filters=order_by_desc(id) HTTP/1.1
 HOST: {deployment}.api.accelo.com
 Authorization: Bearer {access_token}
-
-_filters=order_by_desc(id)
 ```
 
 ```shell
 curl -X GET \
-	https://{deployment}.api.accelo.com/api/v0/activities \
-	-H 'authorization: Bearer {access_token}' \
-	-d '_filters=order_by_desc(id)'
+	"https://{deployment}.api.accelo.com/api/v0/activities?_filters=order_by_desc(id)" \
+	-H 'authorization: Bearer {access_token}'
 ```
 
 These change of the order in which the response is displayed, they are not strictly filters in that they will not
@@ -267,18 +255,15 @@ filters defined:
 > Filter contracts with an empty date_expires:
 
 ```http
-GET /activities HTTP/1.1
+GET /activities?_filters=empty(date_expires) HTTP/1.1
 HOST: {deployment}.api.accelo.com
 Authorization: Bearer {access_token}
-
-_filters=empty(date_expires)
 ```
 
 ```shell
 curl -X GET \
-	https://{deployment}.api.accelo.com/api/v0/activities \
-	-H 'authorization: Bearer {access_token}' \
-	-d '_filters=empty(date_expires)'
+	"https://{deployment}.api.accelo.com/api/v0/activities?_filters=empty(date_expires)" \
+	-H 'authorization: Bearer {access_token}'
 ```
 
 These filter resources which have no value for the given field, the format is `empty(<field_name>)`. For example, the
@@ -297,18 +282,15 @@ all contracts without an expiry date.
 > Filter activities owned by "staff/17"
 
 ```http
-GET /activities HTTP/1.1
+GET /activities?_filters=owner(staff(17)) HTTP/1.1
 HOST: {deployment}.api.accelo.com
 Authorization: Bearer {access_token}
-
-_filters=owner(staff(17))
 ```
 
 ```shell
 curl -X GET \
-	https://{deployment}.api.accelo.com/api/v0/activities \
-	-H 'authorization: Bearer {access_token}' \
-	-d '_filters=owner(staff(17))'
+	"https://{deployment}.api.accelo.com/api/v0/activities?_filters=owner(staff(17))" \
+	-H 'authorization: Bearer {access_token}'
 ```
 
 These are an extension of basic filters that allow for more compact filtering over entire objects, they take both an
@@ -331,18 +313,15 @@ the [affiliation](#affiliations) with id 22.
 >Filter contacts by "kurt wagner"
 
 ```http
-GET /contacts HTTP/1.1
+GET /contacts?_filters=search(kurt%20wagner) HTTP/1.1
 HOST: {deployment}.api.accelo.com
 Authorization: Bearer {access_token}
-
-_filters=search(kurt wagner)
 ```
 
 ```shell
 curl -X GET \
-	https://{deployment}.api.accelo.com/api/v0/contacts \
-	-H 'authorization: Bearer {access_token}' \
-	-d '_filters=search(kurt wagner)'
+	"https://{deployment}.api.accelo.com/api/v0/contacts?_filters=search(kurt%20wagner)" \
+	-H 'authorization: Bearer {access_token}'
 ```
 
 This filter is similar to the [searching](#searching) parameter and supports the same requests available to that
@@ -366,18 +345,15 @@ supports search over `firstname`, `surname`, `mobile`, and `email` so if we want
 > and _not_ against a job
 
 ```http
-GET /activities HTTP/1.1
+GET /activities?_filters=owner(staff(17)),date_created_after(1490140800),against_type_not(job) HTTP/1.1
 HOST: {deployment}.api.accelo.com
 Authorization: Bearer {access_token}
-
-_filters=owner(staff(17)),date_created_after(1490140800),against_type_not(job)
 ```
 
 ```shell
 curl -X GET \
-	https://{deployment}.api.accelo.com/api/v0/activities \
-	-H 'authorization: Bearer {access_token}' \
-	-d '_filters=owner(staff(17)),date_created_after(1490140800),against_type_not(job)'
+	"https://{deployment}.api.accelo.com/api/v0/activities?_filters=owner(staff(17)),date_created_after(1490140800),against_type_not(job)" \
+	-H 'authorization: Bearer {access_token}'
 ```
 
 Any combination of filters may be used to filter response, this is achieved by separating them with a comma. More

--- a/source/includes/_configuring_responses.md
+++ b/source/includes/_configuring_responses.md
@@ -34,18 +34,15 @@ The available parameters are:
 "city" field:
 
 ```http
-GET /companies HTTP/1.1
+GET /companies?_fields=website,phone,postal_address(city) HTTP/1.1
 HOST: {deployment}.api.accelo.com
 Authorization: Bearer {access_token}
-
-_fields=website,phone,postal_address(city)
 ```
 
 ```shell
 curl -X GET \
-	https://{deployment}.api.accelo.com/api/v0/companies \
-	-H 'authorization: Bearer {access_token}' \
-	-d '_fields=website,phone,postal_address(city)'
+	"https://{deployment}.api.accelo.com/api/v0/companies?_fields=website,phone,postal_address(city)" \
+	-H 'authorization: Bearer {access_token}'
 ```
 
 By default, each resource returns only the minimal required fields, these are displayed in the table describing the

--- a/source/includes/_introduction.md
+++ b/source/includes/_introduction.md
@@ -171,6 +171,37 @@ GET /companies/10?_method=delete
 POST /companies/10?_method=delete
 ```
 
+A common use case for `_method=get` is when you need to use a JSON request body to pass complex filters or
+field selections — something GET requests do not support. By sending a POST request with `_method=get` in the
+body, the server treats the request as a GET while still reading the JSON body. This also avoids caching issues
+and network-device rejections that can affect GET requests with a body.
+
+> For example, to list companies and specify fields and filters via a JSON body:
+
+```shell
+curl -X POST \
+	https://{deployment}.api.accelo.com/api/v0/companies \
+	-H 'authorization: Bearer {access_token}' \
+	-H 'content-type: application/json' \
+	-d '{
+	  "_method": "get",
+	  "_fields": "website,phone,postal_address(city)",
+	  "_filters": {
+	    "status": [1, 2]
+	  }
+	}'
+```
+
+```json
+{
+  "_method": "get",
+  "_fields": "website,phone,postal_address(city)",
+  "_filters": {
+    "status": [1, 2]
+  }
+}
+```
+
 
 
 

--- a/source/includes/_introduction.md
+++ b/source/includes/_introduction.md
@@ -171,10 +171,12 @@ GET /companies/10?_method=delete
 POST /companies/10?_method=delete
 ```
 
+While the other override values are most commonly passed as query parameters, `_method=get` has an additional use case: sending a JSON body alongside a logical GET.
+
 A common use case for `_method=get` is when you need to use a JSON request body to pass complex filters or
-field selections — something GET requests do not support. By sending a POST request with `_method=get` in the
-body, the server treats the request as a GET while still reading the JSON body. This also avoids caching issues
-and network-device rejections that can affect GET requests with a body.
+field selections — something GET requests do not support. By sending a POST request with `"_method": "get"` included in the JSON body,
+the server treats the request as a GET while still reading the JSON body. This avoids the caching issues
+and network-device rejections that some HTTP clients and intermediaries impose on GET requests that carry a body.
 
 > For example, to list companies and specify fields and filters via a JSON body:
 
@@ -192,6 +194,8 @@ curl -X POST \
 	}'
 ```
 
+> Request body (JSON only):
+
 ```json
 {
   "_method": "get",
@@ -201,10 +205,6 @@ curl -X POST \
   }
 }
 ```
-
-
-
-
 
 
 ## JSON Content Types

--- a/source/includes/_introduction.md
+++ b/source/includes/_introduction.md
@@ -171,7 +171,7 @@ GET /companies/10?_method=delete
 POST /companies/10?_method=delete
 ```
 
-While the other override values are most commonly passed as query parameters, `_method=get` has an additional use case: sending a JSON body alongside a logical GET.
+Like the other override values, `_method=get` may be passed as a query parameter (e.g. `POST /companies?_method=get`). It also supports passing it directly in the JSON body, which is necessary when you need to include `_fields` or `_filters` in that same JSON body.
 
 A common use case for `_method=get` is when you need to use a JSON request body to pass complex filters or
 field selections — something GET requests do not support. By sending a POST request with `"_method": "get"` included in the JSON body,
@@ -192,18 +192,6 @@ curl -X POST \
 	    "status": [1, 2]
 	  }
 	}'
-```
-
-> Request body (JSON only):
-
-```json
-{
-  "_method": "get",
-  "_fields": "website,phone,postal_address(city)",
-  "_filters": {
-    "status": [1, 2]
-  }
-}
 ```
 
 

--- a/source/includes/_introduction.md
+++ b/source/includes/_introduction.md
@@ -195,10 +195,9 @@ using non-alphanumeric characters e.g "@", "." or special or accented characters
   "_fields": "status(color), username, company(_ALL)"
 ```
 
-When sending JSON data with your request, the `"_fields"` key should hold a string of the desired fields and linked
-objects, separated by a comma. For example, the query `_fields=status` would be equivalent to including `"_fields":
-"status"` in the JSON body. The same method is used to request additional objects and their fields as for queries, the
-"\_ALL" value also works as for queries..
+**Note:** `_fields` in a JSON body is only supported on **POST** and **PUT** requests. On a GET request, request bodies are not processed — pass `_fields` as a query parameter instead (e.g. `?_fields=status`). See [Overriding the Request Method](#overriding-the-request-method) if you need to send a JSON body while performing a logical GET.
+
+When sending JSON data with a POST or PUT request, the `"_fields"` key should hold a string of the desired fields and linked objects, separated by a comma. For example, the query `_fields=status` would be equivalent to including `"_fields": "status"` in the JSON body. The same method is used to request additional objects and their fields as for queries, and the `_ALL` keyword also works as it does for query parameters.
 
 
 


### PR DESCRIPTION
Improves clarity of two sections in the Public API docs:

- **Requesting Additional Fields** — updated the example to show the correct way to pass `_fields` on a GET request
- **JSON Content Types** — added a note clarifying when `_fields` can be used in a JSON body
- **Overriding the Request Method** — added an example showing a practical use case for `_method=get`

Relates to PLAT-478.
